### PR TITLE
Remove unused verifications

### DIFF
--- a/src/domain/factories/comment_on_article_service_factory.rs
+++ b/src/domain/factories/comment_on_article_service_factory.rs
@@ -2,16 +2,14 @@ use crate::domain::services::comment_on_article_service::CommentOnArticleService
 use crate::infra::sea::repositories::sea_article_repository::SeaArticleRepository;
 use crate::infra::sea::repositories::sea_comment_repository::SeaCommentRepository;
 use crate::infra::sea::sea_service::SeaService;
-use crate::infra::sea::repositories::sea_user_repository::SeaUserRepository;
 
-pub async fn exec() -> CommentOnArticleService<SeaCommentRepository, SeaArticleRepository, SeaUserRepository> {
+pub async fn exec() -> CommentOnArticleService<SeaCommentRepository, SeaArticleRepository> {
     let sea_service = SeaService::new().await;
 
     let comment_repository: Box<SeaCommentRepository> = Box::new(SeaCommentRepository::new(sea_service.clone()).await);
-    let article_repository: Box<SeaArticleRepository> = Box::new(SeaArticleRepository::new(sea_service.clone()).await);
-    let user_repository: Box<SeaUserRepository> = Box::new(SeaUserRepository::new(sea_service).await);
+    let article_repository: Box<SeaArticleRepository> = Box::new(SeaArticleRepository::new(sea_service).await);
     
-    let comment_on_article_service = CommentOnArticleService::new(comment_repository, article_repository, user_repository);
+    let comment_on_article_service = CommentOnArticleService::new(comment_repository, article_repository);
 
     comment_on_article_service
 }

--- a/src/domain/factories/create_article_service_factory.rs
+++ b/src/domain/factories/create_article_service_factory.rs
@@ -1,17 +1,14 @@
 use crate::domain::services::create_article_service::CreateArticleService;
 use crate::infra::sea::repositories::sea_article_repository::SeaArticleRepository;
 use crate::infra::sea::sea_service::SeaService;
-use crate::infra::sea::repositories::sea_user_repository::SeaUserRepository;
 
-pub async fn exec() -> CreateArticleService<SeaArticleRepository, SeaUserRepository> {
+pub async fn exec() -> CreateArticleService<SeaArticleRepository> {
     let sea_service = SeaService::new().await;
 
-    let sea_user_repository: Box<SeaUserRepository> = Box::new(SeaUserRepository::new(sea_service.clone()).await);
     let sea_article_repository: Box<SeaArticleRepository> = Box::new(SeaArticleRepository::new(sea_service).await);
 
     let create_article_service = CreateArticleService::new(
         sea_article_repository,
-        sea_user_repository
     );
 
     create_article_service

--- a/src/domain/factories/create_comment_report_service_factory.rs
+++ b/src/domain/factories/create_comment_report_service_factory.rs
@@ -2,17 +2,14 @@ use crate::domain::services::create_comment_report_service::CreateCommentReportS
 use crate::infra::sea::repositories::sea_comment_report_repository::SeaCommentReportRepository;
 use crate::infra::sea::repositories::sea_comment_repository::SeaCommentRepository;
 use crate::infra::sea::sea_service::SeaService;
-use crate::infra::sea::repositories::sea_user_repository::SeaUserRepository;
 
-pub async fn exec() -> CreateCommentReportService<SeaUserRepository, SeaCommentRepository, SeaCommentReportRepository> {
+pub async fn exec() -> CreateCommentReportService<SeaCommentRepository, SeaCommentReportRepository> {
     let sea_service = SeaService::new().await;
     
-    let user_repository: Box<SeaUserRepository> = Box::new(SeaUserRepository::new(sea_service.clone()).await);
     let comment_repository = Box::new(SeaCommentRepository::new(sea_service.clone()).await);
-    let comment_report_repository = Box::new(SeaCommentReportRepository::new(sea_service.clone()).await);
+    let comment_report_repository = Box::new(SeaCommentReportRepository::new(sea_service).await);
     
     let create_comment_report_service = CreateCommentReportService::new(
-        user_repository,
         comment_repository,
         comment_report_repository
     );

--- a/src/domain/factories/create_team_role_service_factory.rs
+++ b/src/domain/factories/create_team_role_service_factory.rs
@@ -1,17 +1,14 @@
 use crate::domain::services::create_team_role_service::CreateTeamRoleService;
 use crate::infra::sea::repositories::sea_team_role_repository::SeaTeamRoleRepository;
 use crate::infra::sea::sea_service::SeaService;
-use crate::infra::sea::repositories::sea_user_repository::SeaUserRepository;
 
-pub async fn exec() -> CreateTeamRoleService<SeaTeamRoleRepository, SeaUserRepository> {
+pub async fn exec() -> CreateTeamRoleService<SeaTeamRoleRepository> {
     let sea_service = SeaService::new().await;
 
-    let sea_user_repository: Box<SeaUserRepository> = Box::new(SeaUserRepository::new(sea_service.clone()).await);
     let sea_team_role_repository: Box<SeaTeamRoleRepository> = Box::new(SeaTeamRoleRepository::new(sea_service).await);
 
     let create_team_role_service = CreateTeamRoleService::new(
         sea_team_role_repository,
-        sea_user_repository,
     );
 
     create_team_role_service

--- a/src/domain/factories/delete_comment_report_service_factory.rs
+++ b/src/domain/factories/delete_comment_report_service_factory.rs
@@ -1,16 +1,13 @@
 use crate::domain::services::delete_comment_report_service::DeleteCommentReportService;
 use crate::infra::sea::repositories::sea_comment_report_repository::SeaCommentReportRepository;
 use crate::infra::sea::sea_service::SeaService;
-use crate::infra::sea::repositories::sea_user_repository::SeaUserRepository;
 
-pub async fn exec() -> DeleteCommentReportService<SeaUserRepository, SeaCommentReportRepository> {
+pub async fn exec() -> DeleteCommentReportService<SeaCommentReportRepository> {
     let sea_service = SeaService::new().await;
 
-    let user_repository: Box<SeaUserRepository> = Box::new(SeaUserRepository::new(sea_service.clone()).await);
     let comment_report_repository: Box<SeaCommentReportRepository> = Box::new(SeaCommentReportRepository::new(sea_service).await);
     
     let delete_comment_report_service = DeleteCommentReportService::new(
-        user_repository,
         comment_report_repository
     );
 

--- a/src/domain/factories/delete_comment_service_factory.rs
+++ b/src/domain/factories/delete_comment_service_factory.rs
@@ -1,15 +1,13 @@
 use crate::domain::services::delete_comment_service::DeleteCommentService;
 use crate::infra::sea::repositories::sea_comment_repository::SeaCommentRepository;
 use crate::infra::sea::sea_service::SeaService;
-use crate::infra::sea::repositories::sea_user_repository::SeaUserRepository;
 
-pub async fn exec() -> DeleteCommentService<SeaCommentRepository, SeaUserRepository> {
+pub async fn exec() -> DeleteCommentService<SeaCommentRepository> {
     let sea_service = SeaService::new().await;
 
-    let user_repository: Box<SeaUserRepository> = Box::new(SeaUserRepository::new(sea_service.clone()).await);
     let comment_repository: Box<SeaCommentRepository> = Box::new(SeaCommentRepository::new(sea_service).await);
     
-    let delete_comment_service = DeleteCommentService::new(comment_repository, user_repository);
+    let delete_comment_service = DeleteCommentService::new(comment_repository);
 
     delete_comment_service
 }

--- a/src/domain/factories/solve_comment_report_service_factory.rs
+++ b/src/domain/factories/solve_comment_report_service_factory.rs
@@ -1,16 +1,13 @@
 use crate::domain::services::solve_comment_report_service::SolveCommentReportService;
 use crate::infra::sea::repositories::sea_comment_report_repository::SeaCommentReportRepository;
 use crate::infra::sea::sea_service::SeaService;
-use crate::infra::sea::repositories::sea_user_repository::SeaUserRepository;
 
-pub async fn exec() -> SolveCommentReportService<SeaUserRepository, SeaCommentReportRepository> {
+pub async fn exec() -> SolveCommentReportService<SeaCommentReportRepository> {
     let sea_service = SeaService::new().await;
     
-    let user_repository: Box<SeaUserRepository> = Box::new(SeaUserRepository::new(sea_service.clone()).await);
-    let comment_report_repository: Box<SeaCommentReportRepository> = Box::new(SeaCommentReportRepository::new(sea_service.clone()).await);
+    let comment_report_repository: Box<SeaCommentReportRepository> = Box::new(SeaCommentReportRepository::new(sea_service).await);
     
     let solve_comment_report_service = SolveCommentReportService::new(
-        user_repository,
         comment_report_repository,
     );
 

--- a/src/domain/factories/toggle_comment_visibility_service_factory.rs
+++ b/src/domain/factories/toggle_comment_visibility_service_factory.rs
@@ -1,16 +1,13 @@
 use crate::infra::sea::sea_service::SeaService;
 use crate::domain::services::toggle_comment_visibility_service::ToggleCommentVisibilityService;
 use crate::infra::sea::repositories::sea_comment_repository::SeaCommentRepository;
-use crate::infra::sea::repositories::sea_user_repository::SeaUserRepository;
 
-pub async fn exec() -> ToggleCommentVisibilityService<SeaUserRepository, SeaCommentRepository> {
+pub async fn exec() -> ToggleCommentVisibilityService<SeaCommentRepository> {
     let sea_service = SeaService::new().await;
     
-    let user_repository: Box<SeaUserRepository> = Box::new(SeaUserRepository::new(sea_service.clone()).await);
     let comment_repository: Box<SeaCommentRepository> = Box::new(SeaCommentRepository::new(sea_service).await);
     
     let toggle_comment_visibility_service = ToggleCommentVisibilityService::new(
-        user_repository,
         comment_repository
     );
 

--- a/src/domain/factories/update_article_service_factory.rs
+++ b/src/domain/factories/update_article_service_factory.rs
@@ -1,17 +1,14 @@
 use crate::domain::services::update_article_service::UpdateArticleService;
 use crate::infra::sea::repositories::sea_article_repository::SeaArticleRepository;
 use crate::infra::sea::sea_service::SeaService;
-use crate::infra::sea::repositories::sea_user_repository::SeaUserRepository;
 
-pub async fn exec() -> UpdateArticleService<SeaArticleRepository, SeaUserRepository> {
+pub async fn exec() -> UpdateArticleService<SeaArticleRepository> {
     let sea_service = SeaService::new().await;
     
-    let user_repository: Box<SeaUserRepository> = Box::new(SeaUserRepository::new(sea_service.clone()).await);
     let article_repository = Box::new(SeaArticleRepository::new(sea_service).await);
     
     let update_article_service = UpdateArticleService::new(
         article_repository,
-        user_repository
     );
 
     update_article_service

--- a/src/domain/services/create_article_service.rs
+++ b/src/domain/services/create_article_service.rs
@@ -2,9 +2,9 @@ use std::error::Error;
 use log::error;
 use uuid::Uuid;
 
-use crate::domain::domain_entities::{article::Article, role::Role};
-use crate::domain::repositories::{article_repository::ArticleRepositoryTrait, user_repository::UserRepositoryTrait};
-use crate::errors::{internal_error::InternalError, unauthorized_error::UnauthorizedError};
+use crate::domain::domain_entities::article::Article;
+use crate::domain::repositories::article_repository::ArticleRepositoryTrait;
+use crate::errors::internal_error::InternalError;
 use crate::{LOG_SEP, R_EOL};
 
 pub struct CreateArticleParams {
@@ -15,46 +15,19 @@ pub struct CreateArticleParams {
 }
 pub struct CreateArticleService<
 ArticleRepository: ArticleRepositoryTrait,
-UserRepository: UserRepositoryTrait
 > {
-    user_repository: Box<UserRepository>,
     article_repository: Box<ArticleRepository>,
 }
 
-impl
-<ArticleRepository: ArticleRepositoryTrait,
-UserRepository: UserRepositoryTrait>
-CreateArticleService<ArticleRepository, UserRepository>
+impl<ArticleRepository: ArticleRepositoryTrait> CreateArticleService<ArticleRepository>
 {
-    pub fn new(article_repository: Box<ArticleRepository>, user_repository: Box<UserRepository>) -> Self {
+    pub fn new(article_repository: Box<ArticleRepository>) -> Self {
         CreateArticleService {
             article_repository,
-            user_repository,
         }
     }
 
     pub async fn exec(&self, params: CreateArticleParams) -> Result<Article, Box<dyn Error>> {
-        let user_on_db = &self.user_repository.find_by_id(&params.author_id).await;
-
-        if user_on_db.is_err() {
-            error!(
-                "{R_EOL}{LOG_SEP}{R_EOL}Error occurred on Create Article Service, while fetching user from database:{R_EOL}{}{R_EOL}{LOG_SEP}{R_EOL}",
-                user_on_db.as_ref().unwrap_err()
-            );
-
-            return Err(
-                Box::new(InternalError::new())
-            );
-        }
-
-        let user_on_db = user_on_db.as_ref().unwrap().to_owned();
-
-        if user_on_db.is_none() || user_on_db.unwrap().role().unwrap() == Role::User {
-            return Err(
-                Box::new(UnauthorizedError::new())
-            )
-        }
-
         let article = Article::new(
             params.author_id,
             params.title,
@@ -81,33 +54,14 @@ CreateArticleService<ArticleRepository, UserRepository>
 mod test {
     use uuid::Uuid;
 
-    use crate::domain::repositories::user_repository::MockUserRepositoryTrait;
     use crate::domain::repositories::article_repository::MockArticleRepositoryTrait;
-    use crate::domain::domain_entities::user::User;
-    use crate::domain::domain_entities::role::Role;
     use super::{Article, CreateArticleParams};
 
     #[tokio::test]
     async fn test() {
-        let mut mocked_user_repo: MockUserRepositoryTrait = MockUserRepositoryTrait::new();
         let mut mocked_article_repo: MockArticleRepositoryTrait = MockArticleRepositoryTrait::new();
 
         let mut db: Vec<Article> = vec![];
-
-        mocked_user_repo
-        .expect_find_by_id()
-        .returning(|id| {
-            let fake_user = User::new_from_existing(
-                id.clone().to_owned(),
-                "Fake name".to_string(),
-                "password".to_string(),
-                chrono::Utc::now().naive_utc(),
-                None,
-                Some(Role::Writter)
-            );
-
-            Ok(Some(fake_user))
-        });
 
         mocked_article_repo
         .expect_create()
@@ -119,7 +73,6 @@ mod test {
         .times(1);
 
         let service = super::CreateArticleService {
-            user_repository: Box::new(mocked_user_repo),
             article_repository: Box::new(mocked_article_repo)
         };
 

--- a/src/domain/services/create_comment_report_service.rs
+++ b/src/domain/services/create_comment_report_service.rs
@@ -5,9 +5,9 @@ use uuid::Uuid;
 use crate::domain::domain_entities::comment_report::DraftCommentReport;
 use crate::domain::domain_entities::comment_report::CommentReport;
 use crate::domain::repositories::comment_repository::CommentRepositoryTrait;
-use crate::domain::repositories::{comment_report_repository::CommentReportRepositoryTrait, user_repository::UserRepositoryTrait};
+use crate::domain::repositories::comment_report_repository::CommentReportRepositoryTrait;
 use crate::errors::bad_request_error::BadRequestError;
-use crate::errors::{internal_error::InternalError, unauthorized_error::UnauthorizedError};
+use crate::errors::internal_error::InternalError;
 
 use crate::{LOG_SEP, R_EOL};
 
@@ -17,58 +17,29 @@ pub struct CreateCommentReportParams {
     pub content: String,
 }
 pub struct CreateCommentReportService<
-UR: UserRepositoryTrait,
 CR: CommentRepositoryTrait,
 CRR: CommentReportRepositoryTrait,
 > {
-    user_repository: Box<UR>,
     comment_repository: Box<CR>,
     comment_report_repository: Box<CRR>
 }
 
 impl<
-UR: UserRepositoryTrait,
 CR: CommentRepositoryTrait,
 CRR: CommentReportRepositoryTrait
 >
-CreateCommentReportService<UR, CR, CRR> {
+CreateCommentReportService<CR, CRR> {
     pub fn new(
-        user_repository: Box<UR>,
         comment_repository: Box<CR>,
         comment_report_repository: Box<CRR>
     ) -> Self {
         CreateCommentReportService {
-            user_repository,
             comment_repository,
             comment_report_repository
         }
     }
 
     pub async fn exec(&self, params: CreateCommentReportParams) -> Result<CommentReport, Box<dyn Error>> {
-        let user_on_db = self.user_repository.find_by_id(&params.user_id).await;
-
-        if user_on_db.is_err() {
-            error!(
-                "{R_EOL}{LOG_SEP}{R_EOL}Error occurred on Create Comment Report Service, while fetching user from database:{R_EOL}{}{R_EOL}{LOG_SEP}{R_EOL}",
-                user_on_db.as_ref().unwrap_err()
-            );
-
-            return Err(
-                Box::new(InternalError::new())
-            );
-        }
-
-        let user_on_db = user_on_db.unwrap().to_owned();
-
-        if user_on_db.is_none() {
-            return Err(
-                Box::new(UnauthorizedError::new())
-            )
-        }
-
-        let user_on_db = user_on_db.unwrap();
-        let user_id = user_on_db.id();
-
         let comment_on_db = self.comment_repository.find_by_id(params.comment_id).await;
         
         if comment_on_db.is_err() {
@@ -95,7 +66,7 @@ CreateCommentReportService<UR, CR, CRR> {
 
         let comment_report = DraftCommentReport::new(
             comment_id,
-            user_id,
+            params.user_id,
             params.content,
         );
 
@@ -125,36 +96,18 @@ mod test {
     use crate::domain::domain_entities::comment::Comment;
     use crate::domain::domain_entities::comment_report::CommentReportTrait;
     use crate::domain::domain_entities::comment_report::DraftCommentReport;
-    use crate::domain::repositories::{comment_repository::MockCommentRepositoryTrait, user_repository::MockUserRepositoryTrait};
+    use crate::domain::repositories::comment_repository::MockCommentRepositoryTrait;
     use crate::domain::repositories::comment_report_repository::MockCommentReportRepositoryTrait;
-    use crate::domain::domain_entities::user::User;
-    use crate::domain::domain_entities::role::Role;
     use super::{CommentReport, CreateCommentReportParams};
 
     #[tokio::test]
     async fn test() {
-        let mut mocked_user_repo: MockUserRepositoryTrait = MockUserRepositoryTrait::new();
         let mut mocked_comment_repo: MockCommentRepositoryTrait = MockCommentRepositoryTrait::new();
         let mut mocked_comment_report_repo: MockCommentReportRepositoryTrait = MockCommentReportRepositoryTrait::new();
 
         type DB = Arc<Mutex<Vec<CommentReport>>>;
 
         let db: DB = Arc::new(Mutex::new(vec![]));
-
-        mocked_user_repo
-        .expect_find_by_id()
-        .returning(|id| {
-            let fake_user = User::new_from_existing(
-                id.clone().to_owned(),
-                "Fake name".to_string(),
-                "password".to_string(),
-                chrono::Utc::now().naive_utc(),
-                None,
-                Some(Role::Writter)
-            );
-            
-            Ok(Some(fake_user))
-        });
 
         mocked_comment_repo
         .expect_find_by_id()
@@ -183,7 +136,6 @@ mod test {
         .times(1);
 
         let service = super::CreateCommentReportService {
-            user_repository: Box::new(mocked_user_repo),
             comment_repository: Box::new(mocked_comment_repo),
             comment_report_repository: Box::new(mocked_comment_report_repo)
         };

--- a/src/domain/services/delete_comment_report_service.rs
+++ b/src/domain/services/delete_comment_report_service.rs
@@ -1,64 +1,34 @@
 use std::error::Error;
 use log::error;
 
+use crate::domain::domain_entities::role::Role;
 use crate::errors::bad_request_error::BadRequestError;
 use crate::errors::unauthorized_error::UnauthorizedError;
 use crate::{R_EOL, LOG_SEP};
 
-use uuid::Uuid;
-
 use crate::domain::repositories::comment_report_repository::CommentReportRepositoryTrait;
-use crate::domain::repositories::user_repository::UserRepositoryTrait;
 use crate::errors::internal_error::InternalError;
 use crate::util::verify_role_has_permission;
 use crate::util::RolePermissions;
 
 pub struct DeleteCommentReportParams {
-    pub staff_id: Uuid,
+    pub staff_role: Role,
     pub com_report_id: i32,
 }
 
-pub struct DeleteCommentReportService<UserRepository, CommentReportRepository>
-where   UserRepository: UserRepositoryTrait,
-        CommentReportRepository: CommentReportRepositoryTrait
-{
-    user_repository: Box<UserRepository>,
-    comment_report_repository: Box<CommentReportRepository>
-}
+pub struct DeleteCommentReportService<CommentReportRepository: CommentReportRepositoryTrait>
+{ comment_report_repository: Box<CommentReportRepository> }
 
-impl<
-UserRepository: UserRepositoryTrait,
-CommentReportRepository: CommentReportRepositoryTrait
->
-DeleteCommentReportService<UserRepository, CommentReportRepository> {
-    pub fn new(user_repository: Box<UserRepository>, comment_report_repository: Box<CommentReportRepository>) -> Self {
+impl<CommentReportRepository: CommentReportRepositoryTrait>
+DeleteCommentReportService<CommentReportRepository> {
+    pub fn new(comment_report_repository: Box<CommentReportRepository>) -> Self {
         DeleteCommentReportService {
-            user_repository,
             comment_report_repository
         }
     }
 
     pub async fn exec(&self, params: DeleteCommentReportParams) -> Result<(), Box<dyn Error>> {
-        let staff_on_db = self.user_repository.find_by_id(&params.staff_id).await;
-
-        if staff_on_db.is_err() {
-            error!(
-                "{R_EOL}{LOG_SEP}{R_EOL}Error occurred on Delete Comment Report Service, while fetching the staff from database: {R_EOL}{}{R_EOL}{LOG_SEP}{R_EOL}",
-                staff_on_db.unwrap_err()
-            );
-
-            return Err( Box::new( InternalError::new() ) )
-        }
-
-        let staff_on_db = staff_on_db.unwrap();
-
-        if staff_on_db.is_none() {
-            return Err( Box::new( UnauthorizedError::new() ) );
-        }
-        
-        let staff_on_db = staff_on_db.unwrap();
-
-        let staff_can_delete = verify_role_has_permission(&staff_on_db.role().unwrap(), RolePermissions::DeleteReport);
+        let staff_can_delete = verify_role_has_permission(&params.staff_role, RolePermissions::DeleteReport);
 
         if !staff_can_delete {
             return Err( Box::new( UnauthorizedError::new() ) );
@@ -104,39 +74,24 @@ mod test {
     use std::sync::{Arc, Mutex};
 
     use crate::domain::domain_entities::comment_report::{CommentReport, CommentReportIdTrait};
-    use crate::domain::domain_entities::role::Role;
-    use crate::domain::domain_entities::user::User;
     use crate::domain::repositories::comment_report_repository::MockCommentReportRepositoryTrait;
-    use crate::domain::repositories::user_repository::MockUserRepositoryTrait;
-    
+
     use tokio;
     use chrono::Utc;
+    use uuid::Uuid;
 
     #[tokio::test]
     async fn test() {
-        let mut mocked_user_repo = MockUserRepositoryTrait::new();
         let mut mocked_comment_report_repo = MockCommentReportRepositoryTrait::new();
 
         type CommentReportDB = Arc<Mutex<Vec<CommentReport>>>;
-        type UserDB = Arc<Mutex<Vec<User>>>;
 
         let comm_report_db: CommentReportDB = Arc::new(Mutex::new(vec![]));
-        let user_db: UserDB = Arc::new(Mutex::new(vec![]));
-
-        let floricultor_user = User::new("Floricultor".into(), "123".into(), Some(Role::Principal));
-        let floricultor_id = floricultor_user.id();
-
-        user_db.lock().unwrap().push(floricultor_user);
-
-        let rnd_user = User::new("Jack".into(), "123".into(), Some(Role::User));
-        let rnd_user_id = rnd_user.id();
-
-        user_db.lock().unwrap().push(rnd_user);
 
         let comment_report_1 = CommentReport::new_from_existing(
             1,
             Uuid::new_v4(),
-            rnd_user_id.clone(),
+            Uuid::new_v4(),
             "Esse comentário é tóxico.".into(),
             false,
             Utc::now().naive_utc()
@@ -147,7 +102,7 @@ mod test {
         let comment_report_2 = CommentReport::new_from_existing(
             2,
             Uuid::new_v4(),
-            rnd_user_id.clone(),
+            Uuid::new_v4(),
             "Estão me ofendendo neste comentário!".into(),
             false,
             Utc::now().naive_utc()
@@ -157,22 +112,6 @@ mod test {
 
         comm_report_db.lock().unwrap().push(comment_report_1);
         comm_report_db.lock().unwrap().push(comment_report_2);
-
-        let user_db_clone = Arc::clone(&user_db);
-        mocked_user_repo
-        .expect_find_by_id()
-        .returning(move |id| {
-            let mut _user: Option<User> = None;
-
-            for user in user_db_clone.lock().unwrap().iter() {
-                if user.id().eq(id) {
-                    _user = Some(user.clone());
-                    break;
-                }
-            }
-
-            Ok(_user)
-        });
 
         let comm_report_db_clone = Arc::clone(&comm_report_db);
         mocked_comment_report_repo
@@ -208,12 +147,11 @@ mod test {
         });
 
         let sut = DeleteCommentReportService {
-            user_repository: Box::new(mocked_user_repo),
             comment_report_repository: Box::new(mocked_comment_report_repo)
         };
 
         let result = sut.exec(DeleteCommentReportParams {
-            staff_id: floricultor_id,
+            staff_role: Role::Principal,
             com_report_id: comment_report_id_1
         }).await;
 
@@ -221,7 +159,7 @@ mod test {
         assert_ne!(comment_report_id_1, comm_report_db.lock().unwrap()[0].id());
 
         let result_2 = sut.exec(DeleteCommentReportParams {
-            staff_id: rnd_user_id,
+            staff_role: Role::User,
             com_report_id: comment_report_id_2
         }).await;
 

--- a/src/domain/services/delete_comment_service.rs
+++ b/src/domain/services/delete_comment_service.rs
@@ -2,56 +2,33 @@ use std::error::Error;
 use log::error;
 use uuid::Uuid;
 
+use crate::domain::domain_entities::role::Role;
 use crate::{LOG_SEP, R_EOL};
 
 use crate::domain::repositories::comment_repository::CommentRepositoryTrait;
-use crate::domain::repositories::user_repository::UserRepositoryTrait;
 use crate::errors::resource_not_found::ResourceNotFoundError;
 use crate::errors::{internal_error::InternalError, unauthorized_error::UnauthorizedError};
 use crate::util::{RolePermissions, verify_role_has_permission};
 
 pub struct DeleteCommentParams {
+    pub staff_role: Role,
     pub user_id: Uuid,
     pub comment_id: Uuid,
 }
-pub struct DeleteCommentService<
-CommentRepository: CommentRepositoryTrait,
-UserRepository: UserRepositoryTrait
-> {
-    user_repository: Box<UserRepository>,
+pub struct DeleteCommentService<CommentRepository: CommentRepositoryTrait> {
     comment_repository: Box<CommentRepository>,
 }
 
-impl
-<CommentRepository: CommentRepositoryTrait,
-UserRepository: UserRepositoryTrait>
-DeleteCommentService<CommentRepository, UserRepository>
+impl<CommentRepository: CommentRepositoryTrait>
+DeleteCommentService<CommentRepository>
 {
-    pub fn new(comment_repository: Box<CommentRepository>, user_repository: Box<UserRepository>) -> Self {
+    pub fn new(comment_repository: Box<CommentRepository>) -> Self {
         DeleteCommentService {
             comment_repository,
-            user_repository,
         }
     }
 
     pub async fn exec(&self, params: DeleteCommentParams) -> Result<(), Box<dyn Error>> {
-        let user_on_db = &self.user_repository.find_by_id(&params.user_id).await;
-
-        if user_on_db.is_err() {
-            error!(
-                "{R_EOL}{LOG_SEP}{R_EOL}Error occurred on Delete Comment Service, while finding user by Id: {R_EOL}{}{R_EOL}{LOG_SEP}{R_EOL}",
-                user_on_db.as_ref().unwrap_err()
-            );
-
-            return Err(Box::new(InternalError::new()));
-        }
-
-        let user_on_db = user_on_db.as_ref().unwrap().to_owned();
-
-        if user_on_db.is_none() { return Err(Box::new(UnauthorizedError::new())) }
-
-        // comment verifications
-
         let comment_on_db = self.comment_repository.find_by_id(params.comment_id).await;
 
         if comment_on_db.is_err() {
@@ -71,7 +48,7 @@ DeleteCommentService<CommentRepository, UserRepository>
 
         // checks user is allowed to perform the update
         let user_can_delete = verify_role_has_permission(
-            &user_on_db.as_ref().unwrap().role().unwrap().clone().to_owned(),
+            &params.staff_role,
             RolePermissions::DeleteComment
         );
 
@@ -101,15 +78,12 @@ mod test {
 
     use super::{DeleteCommentParams, DeleteCommentService};
 
-    use crate::domain::repositories::user_repository::MockUserRepositoryTrait;
     use crate::domain::repositories::comment_repository::MockCommentRepositoryTrait;
-    use crate::domain::domain_entities::user::User;
     use crate::domain::domain_entities::role::Role;
     use crate::domain::domain_entities::comment::Comment;
 
     #[tokio::test]
     async fn test() {
-        let mut mocked_user_repo: MockUserRepositoryTrait = MockUserRepositoryTrait::new();
         let mut mocked_comment_repo: MockCommentRepositoryTrait = MockCommentRepositoryTrait::new();
 
         let comment = Comment::new(
@@ -122,24 +96,7 @@ mod test {
             comment.clone()
         ]));
         
-        // mocking user repo
-        mocked_user_repo
-        .expect_find_by_id()
-        .returning(|id| {
-            let fake_user = User::new_from_existing(
-                id.clone().to_owned(),
-                "Fake name".to_string(),
-                "password".to_string(),
-                chrono::Utc::now().naive_utc(),
-                None,
-                Some(Role::Principal)
-            );
-
-            Ok(Some(fake_user))
-        });
-
         // mocking comment repo
-    
         let mocked_comment_repo_db_clone = Arc::clone(&comment_db);
         mocked_comment_repo
         .expect_find_by_id()
@@ -166,12 +123,12 @@ mod test {
         });
 
         let service = DeleteCommentService {
-            user_repository: Box::new(mocked_user_repo),
             comment_repository: Box::new(mocked_comment_repo)
         };
 
         let result = service.exec(DeleteCommentParams {
             user_id: comment.author_id(),
+            staff_role: Role::User,
             comment_id: comment.id(),
         });
 

--- a/src/domain/services/solve_comment_report_service.rs
+++ b/src/domain/services/solve_comment_report_service.rs
@@ -1,64 +1,35 @@
 use std::error::Error;
 use log::error;
 
+use crate::domain::domain_entities::role::Role;
 use crate::errors::resource_not_found::ResourceNotFoundError;
 use crate::errors::unauthorized_error::UnauthorizedError;
 use crate::{R_EOL, LOG_SEP};
 
-use uuid::Uuid;
-
 use crate::domain::repositories::comment_report_repository::CommentReportRepositoryTrait;
-use crate::domain::repositories::user_repository::UserRepositoryTrait;
 use crate::errors::internal_error::InternalError;
 use crate::util::verify_role_has_permission;
 use crate::util::RolePermissions;
 
 pub struct SolveCommentReportParams {
-    pub staff_id: Uuid,
+    pub staff_role: Role,
     pub com_report_id: i32,
 }
 
-pub struct SolveCommentReportService<UserRepository, CommentReportRepository>
-where   UserRepository: UserRepositoryTrait,
-        CommentReportRepository: CommentReportRepositoryTrait
-{
-    user_repository: Box<UserRepository>,
+pub struct SolveCommentReportService<CommentReportRepository: CommentReportRepositoryTrait> {
     comment_report_repository: Box<CommentReportRepository>
 }
 
-impl<
-UserRepository: UserRepositoryTrait,
-CommentReportRepository: CommentReportRepositoryTrait
->
-SolveCommentReportService<UserRepository, CommentReportRepository> {
-    pub fn new(user_repository: Box<UserRepository>, comment_report_repository: Box<CommentReportRepository>) -> Self {
+impl<CommentReportRepository: CommentReportRepositoryTrait>
+SolveCommentReportService<CommentReportRepository> {
+    pub fn new(comment_report_repository: Box<CommentReportRepository>) -> Self {
         SolveCommentReportService {
-            user_repository,
             comment_report_repository
         }
     }
 
     pub async fn exec(&self, params: SolveCommentReportParams) -> Result<(), Box<dyn Error>> {
-        let staff_on_db = self.user_repository.find_by_id(&params.staff_id).await;
-
-        if staff_on_db.is_err() {
-            error!(
-                "{R_EOL}{LOG_SEP}{R_EOL}Error occurred on Solve Comment Report Service, while fetching the staff from database: {R_EOL}{}{R_EOL}{LOG_SEP}{R_EOL}",
-                staff_on_db.unwrap_err()
-            );
-
-            return Err( Box::new( InternalError::new() ) )
-        }
-
-        let staff_on_db = staff_on_db.unwrap();
-
-        if staff_on_db.is_none() {
-            return Err( Box::new( UnauthorizedError::new() ) );
-        }
-        
-        let staff_on_db = staff_on_db.unwrap();
-
-        let staff_can_solve = verify_role_has_permission(&staff_on_db.role().unwrap(), RolePermissions::SolveReport);
+        let staff_can_solve = verify_role_has_permission(&params.staff_role, RolePermissions::SolveReport);
 
         if !staff_can_solve {
             return Err( Box::new( UnauthorizedError::new() ) );
@@ -107,38 +78,24 @@ mod test {
 
     use crate::domain::domain_entities::comment_report::{CommentReport, CommentReportIdTrait, CommentReportTrait};
     use crate::domain::domain_entities::role::Role;
-    use crate::domain::domain_entities::user::User;
     use crate::domain::repositories::comment_report_repository::MockCommentReportRepositoryTrait;
-    use crate::domain::repositories::user_repository::MockUserRepositoryTrait;
     
     use tokio;
     use chrono::Utc;
+    use uuid::Uuid;
 
     #[tokio::test]
     async fn test() {
-        let mut mocked_user_repo = MockUserRepositoryTrait::new();
         let mut mocked_comment_report_repo = MockCommentReportRepositoryTrait::new();
 
         type CommentReportDB = Arc<Mutex<Vec<CommentReport>>>;
-        type UserDB = Arc<Mutex<Vec<User>>>;
 
         let comm_report_db: CommentReportDB = Arc::new(Mutex::new(vec![]));
-        let user_db: UserDB = Arc::new(Mutex::new(vec![]));
-
-        let floricultor_user = User::new("Floricultor".into(), "123".into(), Some(Role::Coord));
-        let floricultor_id = floricultor_user.id();
-
-        user_db.lock().unwrap().push(floricultor_user);
-
-        let rnd_user = User::new("Jack".into(), "123".into(), Some(Role::User));
-        let rnd_user_id = rnd_user.id();
-
-        user_db.lock().unwrap().push(rnd_user);
 
         let comment_report_1 = CommentReport::new_from_existing(
             1,
             Uuid::new_v4(),
-            rnd_user_id.clone(),
+            Uuid::new_v4(),
             "Esse comentário é tóxico.".into(),
             false,
             Utc::now().naive_utc()
@@ -149,7 +106,7 @@ mod test {
         let comment_report_2 = CommentReport::new_from_existing(
             2,
             Uuid::new_v4(),
-            rnd_user_id.clone(),
+            Uuid::new_v4(),
             "Estão me ofendendo neste comentário!".into(),
             false,
             Utc::now().naive_utc()
@@ -159,22 +116,6 @@ mod test {
 
         comm_report_db.lock().unwrap().push(comment_report_1);
         comm_report_db.lock().unwrap().push(comment_report_2);
-
-        let user_db_clone = Arc::clone(&user_db);
-        mocked_user_repo
-        .expect_find_by_id()
-        .returning(move |id| {
-            let mut _user: Option<User> = None;
-
-            for user in user_db_clone.lock().unwrap().iter() {
-                if user.id().eq(id) {
-                    _user = Some(user.clone());
-                    break;
-                }
-            }
-
-            Ok(_user)
-        });
 
         let comm_report_db_clone = Arc::clone(&comm_report_db);
         mocked_comment_report_repo
@@ -212,12 +153,11 @@ mod test {
         });
 
         let sut = SolveCommentReportService {
-            user_repository: Box::new(mocked_user_repo),
             comment_report_repository: Box::new(mocked_comment_report_repo)
         };
 
         let result = sut.exec(SolveCommentReportParams {
-            staff_id: floricultor_id,
+            staff_role: Role::Coord,
             com_report_id: comment_report_id_1
         }).await;
 
@@ -225,7 +165,7 @@ mod test {
         assert_eq!(true, comm_report_db.lock().unwrap()[0].solved());
 
         let result_2 = sut.exec(SolveCommentReportParams {
-            staff_id: rnd_user_id,
+            staff_role: Role::User,
             com_report_id: comment_report_id_2
         }).await;
 

--- a/src/domain/services/toggle_comment_visibility_service.rs
+++ b/src/domain/services/toggle_comment_visibility_service.rs
@@ -3,7 +3,7 @@ use log::error;
 use uuid::Uuid;
 
 use crate::domain::domain_entities::comment::Comment;
-use crate::domain::repositories::user_repository::UserRepositoryTrait;
+use crate::domain::domain_entities::role::Role;
 use crate::domain::repositories::comment_repository::CommentRepositoryTrait;
 use crate::errors::internal_error::InternalError;
 use crate::errors::unauthorized_error::UnauthorizedError;
@@ -12,46 +12,26 @@ use crate::util::{verify_role_has_permission, RolePermissions};
 use crate::{LOG_SEP, R_EOL};
 
 pub struct ToggleCommentVisibilityParams {
-    pub user_id: Uuid,
+    pub user_role: Role,
     pub comment_id: Uuid
 }
 
-pub struct ToggleCommentVisibilityService <UserRepository: UserRepositoryTrait, CommentRepository: CommentRepositoryTrait> {
-    user_repository: Box<UserRepository>,
+pub struct ToggleCommentVisibilityService <CommentRepository: CommentRepositoryTrait> {
     comment_repository: Box<CommentRepository>
 }
 
-impl<UserRepository: UserRepositoryTrait, CommentRepository: CommentRepositoryTrait>
-ToggleCommentVisibilityService<UserRepository, CommentRepository> {
+impl<CommentRepository: CommentRepositoryTrait>
+ToggleCommentVisibilityService<CommentRepository> {
     pub fn new(
-        user_repository: Box<UserRepository>,
         comment_repository: Box<CommentRepository>
     ) -> Self {
         ToggleCommentVisibilityService {
-            user_repository,
             comment_repository
         }
     }
 
     pub async fn exec(&self, params: ToggleCommentVisibilityParams) -> Result<Comment, Box<dyn Error>> {
-        let user_on_db = self.user_repository.find_by_id(&params.user_id).await;
-
-        if user_on_db.is_err() {
-            error!(
-                "{R_EOL}{LOG_SEP}{R_EOL}Error occurred on Toggle Comment Visibility Service, while finding user by id: {R_EOL}{}{R_EOL}{LOG_SEP}{R_EOL}",
-                user_on_db.as_ref().unwrap_err()
-            );
-
-            return Err(Box::new(InternalError::new()));
-        }
-
-        let user_on_db = user_on_db.as_ref().unwrap().to_owned();
-
-        if user_on_db.is_none() { return Err(Box::new(UnauthorizedError::new())) }
-    
-        let user = user_on_db.unwrap();
-
-        let user_can_toggle_visibility = verify_role_has_permission(&user.role().unwrap(), RolePermissions::InactivateComment);
+        let user_can_toggle_visibility = verify_role_has_permission(&params.user_role, RolePermissions::InactivateComment);
 
         if !user_can_toggle_visibility {
             return Err(Box::new(UnauthorizedError::new()));
@@ -101,8 +81,6 @@ mod test {
     use super::*;
 
     use crate::domain::domain_entities::role::Role;
-    use crate::domain::domain_entities::user::User;
-    use crate::domain::repositories::user_repository::MockUserRepositoryTrait;
     use crate::domain::repositories::comment_repository::MockCommentRepositoryTrait;
 
     use tokio;
@@ -111,34 +89,14 @@ mod test {
     #[tokio::test]
     async fn test() {
         // POPULATING THE DATABASE
-        let user_db: Arc<Mutex<Vec<User>>> = Arc::new(Mutex::new(vec![]));
         let comment_db: Arc<Mutex<Vec<Comment>>> = Arc::new(Mutex::new(vec![]));
 
-        let editor_user = User::new("Floricultor".into(), "123".into(), Some(Role::Editor));
-        let coord_user = User::new("Floricultor".into(), "123".into(), Some(Role::Coord));
         let comment = Comment::new(Uuid::new_v4(), Some(Uuid::new_v4()), "Comment content haha".into());
 
         comment_db.lock().unwrap().push(comment.clone());
-        user_db.lock().unwrap().push(editor_user.clone());
-        user_db.lock().unwrap().push(coord_user.clone());
 
         // MOCKED REPOSITORIES
-        let mut mocked_user_repo = MockUserRepositoryTrait::new();
         let mut mocked_comment_repo = MockCommentRepositoryTrait::new();
-
-        let user_db_clone = Arc::clone(&user_db);
-        mocked_user_repo
-        .expect_find_by_id()
-        .returning(move |id| {
-            let mut user = None;
-
-            for item in user_db_clone.lock().unwrap().iter() {
-                if item.id().eq(id) {
-                    user = Some(item.clone());
-                }
-            }
-            Ok(user)
-        });
 
         let comment_db_clone = Arc::clone(&comment_db);
         mocked_comment_repo
@@ -167,12 +125,11 @@ mod test {
 
         // SERVICE INSTANCIATING
         let sut = ToggleCommentVisibilityService {
-            user_repository: Box::new(mocked_user_repo),
             comment_repository: Box::new(mocked_comment_repo)
         };
 
         let res = sut.exec(ToggleCommentVisibilityParams {
-            user_id: editor_user.id(),
+            user_role: Role::Editor,
             comment_id: comment.id(),
         }).await;
 
@@ -180,7 +137,7 @@ mod test {
         assert_eq!(true, comment_db.lock().unwrap()[0].is_active());
 
         let res = sut.exec(ToggleCommentVisibilityParams {
-            user_id: coord_user.id(),
+            user_role: Role::Coord,
             comment_id: comment.id(),
         }).await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ async fn main() {
     let res = _ctrs.exec(CreateTeamRoleParams {
         title: "Desenvolvedor".into(),
         description: "Desenvolver novas funcionalidades para o fã-site.".into(),
-        staff_id: _floricultor_user.id()
+        staff_role: _floricultor_user.role().unwrap()
     }).await;
 
     println!("{:?}", res.unwrap());


### PR DESCRIPTION
Remove unecessary user database query from near-every service.

Services where querying the user on the database everytime in order to verify if the user does exist and (if applicable) have the permission to perform that action.

Being sure the user exist and it's id and role is real is a controller responsability tho. If the service is called, it means the controller verified by JWT that the user does exist and, so, it's role is also his real role.

Said that, there is no need for the services to re-verify this and perform this extra database query, even thought it guaranteed a bit of extra security. 