### PR TITLE
fix(deploy workflow): change steps order

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,6 +31,14 @@ jobs:
       - name: Build the Rust application
         run: cargo build --release
 
+      - name: Delete old public directory from Square Cloud
+        run: |
+          curl --request DELETE \
+            --url https://api.squarecloud.app/v2/apps/${{ secrets.square_app_id }}/files \
+            --header "Authorization: ${{ secrets.square_token }}" \
+            --header 'Content-Type: application/json' \
+            --data '{ "path": "public" }'
+
       - name: Build the front-end
         run: |
           npm install
@@ -63,15 +71,6 @@ jobs:
         with:
           token: ${{ secrets.square_token }}
           install-only: true
-        
-      - name: Delete old public directory from the host
-        run: |
-          curl --request DELETE \
-            --url https://api.squarecloud.app/v2/apps/${{ secrets.square_app_id }}/files \
-            --header "Authorization: ${{ secrets.square_token }}" \
-            --header 'Content-Type: application/json' \
-            --data '{ "path": "public" }'
-
 
       - name: Commit the application to the host
         run: |


### PR DESCRIPTION
Delete the `public` directory before even building the front-end bundle, so that Square Cloud doesn't accidentaly delete the new incoming `public` directory