### PR TITLE
build(deploy workflow): setup rust-cache action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,6 +23,9 @@ jobs:
           rustup update stable
           rustup default stable
 
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
@@ -35,6 +38,8 @@ jobs:
         run: |
           npm install
           npm run build
+
+      
 
       - name: Make __package directory
         run: mkdir -p __package/www


### PR DESCRIPTION
This is an attempt of reducing the cargo build time (which can take over 8 minutes)