### PR TITLE
fix: script not working properly & comment reports behavior

### DIFF
--- a/www/pages/articles/show.tsx
+++ b/www/pages/articles/show.tsx
@@ -12,27 +12,16 @@ import { ArticleScript } from "@/ui/articles/article-script";
 import { CommentsSection } from "@/ui/articles/comments-section";
 import { decodeQuotes } from "@/utils/quotes";
 
-type Props = PageProps & {
+export type ShowArticleProps = PageProps & {
   article: ExpandedArticle;
   feed: Paginated<ArticlePreview[]>;
 };
 
-export default function ShowArticle(props: Props) {
+export default function ShowArticle(props: ShowArticleProps) {
   const articleContent = useMemo(
     () => decodeQuotes(props.article.content),
     [props.article.content],
   );
-
-  const script = useMemo(() => {
-    const script = props.article.script?.trim() ?? "";
-    return script === "" ? null : decodeQuotes(script);
-  }, [props.article.script]);
-
-  const cleanupScript = useMemo(() => {
-    if (!script) return null;
-    const cleanupScript = props.article.cleanupScript?.trim() ?? "";
-    return cleanupScript === "" ? null : decodeQuotes(cleanupScript);
-  }, [props.article.cleanupScript, script]);
 
   return (
     <>
@@ -64,7 +53,7 @@ export default function ShowArticle(props: Props) {
 
       <ArticleFeed {...props.feed} />
 
-      {script && <ArticleScript script={script} cleanupScript={cleanupScript} />}
+      <ArticleScript />
     </>
   );
 }

--- a/www/ui/articles/article-script.tsx
+++ b/www/ui/articles/article-script.tsx
@@ -1,23 +1,41 @@
-import { useEffect, useId } from "react";
+import { usePage } from "@inertiajs/react";
+import { useEffect, useId, useMemo } from "react";
+import type { ShowArticleProps } from "@/pages/articles/show";
+import { decodeQuotes } from "@/utils/quotes";
 
-type Props = {
-  script: string;
-  cleanupScript: string | null;
-};
+type ExtendedWindow = Window &
+  typeof globalThis & {
+    [HAS_INJECTED_SCRIPT_KEY]: boolean | undefined;
+  };
 
 const event: keyof WindowEventMap = "load";
 const HAS_INJECTED_SCRIPT_KEY = "__clientside_script_has_been_injected";
 
-export function ArticleScript({ script, cleanupScript }: Props) {
+export function ArticleScript() {
+  const page = usePage<ShowArticleProps>();
   const scriptId = useId();
+
+  const script = useMemo(() => {
+    const script = page.props.article.script?.trim() ?? "";
+    return script === "" ? null : decodeQuotes(script);
+  }, [page.props.article.script]);
+
+  const cleanupScript = useMemo(() => {
+    if (!script) return null;
+    const cleanupScript = page.props.article.cleanupScript?.trim() ?? "";
+    return cleanupScript === "" ? null : decodeQuotes(cleanupScript);
+  }, [page.props.article.cleanupScript, script]);
+
   useEffect(() => {
+    if (!page.props.article.script || !script) return;
+
     const setHasInjectedScript = (value: boolean) => {
-      (window as unknown as Record<string, unknown>)[HAS_INJECTED_SCRIPT_KEY] = value;
+      (window as ExtendedWindow)[HAS_INJECTED_SCRIPT_KEY] = value;
     };
 
     const hasInjectedScript = (): boolean => {
-      const hasInjected = (window as unknown as Record<string, unknown>)[HAS_INJECTED_SCRIPT_KEY];
-      return (hasInjected as boolean) ?? false;
+      const hasInjected = (window as ExtendedWindow)[HAS_INJECTED_SCRIPT_KEY];
+      return hasInjected ?? false;
     };
 
     const injectScripts = () => {
@@ -56,7 +74,7 @@ export function ArticleScript({ script, cleanupScript }: Props) {
         cleanup();
       }
     };
-  }, [script, cleanupScript, scriptId]);
+  }, [script, cleanupScript, scriptId, page]);
 
   return null;
 }

--- a/www/ui/articles/article-script.tsx
+++ b/www/ui/articles/article-script.tsx
@@ -1,5 +1,6 @@
 import { usePage } from "@inertiajs/react";
 import { useEffect, useId, useMemo } from "react";
+import { toast } from "react-toastify";
 import type { ShowArticleProps } from "@/pages/articles/show";
 import { decodeQuotes } from "@/utils/quotes";
 
@@ -45,19 +46,21 @@ export function ArticleScript() {
       scriptElement.id = scriptId;
 
       document.body.appendChild(scriptElement);
+
+      setTimeout(() => {
+        setHasInjectedScript(true);
+      }, 0);
     };
 
     const removeScripts = () => {
       const scriptElement = document.getElementById(scriptId);
       if (scriptElement) document.body.removeChild(scriptElement);
+      setHasInjectedScript(false);
     };
 
     const injectScriptsOnce = () => {
-      if (hasInjectedScript()) return;
-      setHasInjectedScript(true);
-
-      injectScripts();
       window.removeEventListener(event, injectScriptsOnce);
+      if (!hasInjectedScript()) injectScripts();
     };
 
     window.addEventListener(event, injectScriptsOnce);
@@ -66,13 +69,18 @@ export function ArticleScript() {
 
     return () => {
       window.removeEventListener(event, injectScriptsOnce);
-      removeScripts();
-      setHasInjectedScript(false);
 
-      if (cleanupScript) {
+      if (cleanupScript && hasInjectedScript()) {
         const cleanup = new Function(cleanupScript);
-        cleanup();
+        try {
+          cleanup();
+        } catch (error) {
+          console.error("An error occurred when running cleanup script", error);
+          toast.error("Houve um problema ao rodar o script de limpeza desta notícia.");
+        }
       }
+
+      removeScripts();
     };
   }, [script, cleanupScript, scriptId, page]);
 

--- a/www/ui/articles/report-comment-dialog.tsx
+++ b/www/ui/articles/report-comment-dialog.tsx
@@ -39,6 +39,7 @@ export const ReportCommentDialog = forwardRef<HTMLButtonElement, Props>(
             toast.success("Denúncia realizada com sucesso.");
             setOpen(false);
           },
+          preserveScroll: true,
         });
       },
       [post, comment, setOpen],

--- a/www/ui/articles/report-comment-dialog.tsx
+++ b/www/ui/articles/report-comment-dialog.tsx
@@ -5,6 +5,7 @@ import {
   forwardRef,
   type ReactElement,
   useCallback,
+  useEffect,
   useId,
 } from "react";
 import { toast } from "react-toastify";
@@ -29,7 +30,9 @@ export const ReportCommentDialog = forwardRef<HTMLButtonElement, Props>(
   ({ trigger, comment, open, setOpen, ...props }, ref) => {
     const formId = useId();
 
-    const { post, processing, errors, setData } = useForm<ReportCommentFormData>({ content: "" });
+    const { post, processing, errors, setData, wasSuccessful } = useForm<ReportCommentFormData>({
+      content: "",
+    });
 
     const handleReportComment = useCallback(
       (e: FormEvent) => {
@@ -90,8 +93,8 @@ export const ReportCommentDialog = forwardRef<HTMLButtonElement, Props>(
             </Dialog.Close>
 
             <PublicButton.Default
-              disabled={processing}
-              aria-busy={processing}
+              disabled={processing || wasSuccessful}
+              aria-busy={processing || wasSuccessful}
               type="submit"
               form={`report-comment-form-${formId}`}
               variant="yellow">


### PR DESCRIPTION
Changes article's scripts (and cleanup scripts) injections, executions, and removals:
- only enable injection flag after appending script element
- reruns scripts removal and injection on every re-render (so that scripts always hold fresh reference to DOM elements)

It also perform some changes in comment reports:
- preserve scroll on submitting the report (what stops a visual glitch when closing the report dialog)
- disable the submit button after successful submit (to avoid double submit upon fast pressing `enter` key or even when trying to report the same comment without at least refreshing the page, which might reduce report spamming)