### PR TITLE
feat: add article tag management pages

### DIFF
--- a/src/domain/factories/journalism/article_tags/find_article_tag_by_id_service_factory.rs
+++ b/src/domain/factories/journalism/article_tags/find_article_tag_by_id_service_factory.rs
@@ -1,0 +1,12 @@
+use sea_orm::DatabaseConnection;
+
+use crate::domain::services::journalism::article_tags::find_article_tag_by_id_service::FindArticleTagByIdService;
+use crate::infra::sea::repositories::sea_article_tag_repository::SeaArticleTagRepository;
+use crate::infra::sea::sea_service::SeaService;
+
+pub fn exec(
+    db_conn: &SeaService,
+) -> FindArticleTagByIdService<SeaArticleTagRepository<'_, DatabaseConnection>> {
+    let article_tag_repository = SeaArticleTagRepository::new(&db_conn.db);
+    FindArticleTagByIdService::new(article_tag_repository)
+}

--- a/src/domain/factories/journalism/article_tags/mod.rs
+++ b/src/domain/factories/journalism/article_tags/mod.rs
@@ -1,4 +1,5 @@
 pub mod create_article_tag_service_factory;
 pub mod delete_article_tag_service_factory;
 pub mod fetch_many_article_tags_service_factory;
+pub mod find_article_tag_by_id_service_factory;
 pub mod update_article_tag_service_factory;

--- a/src/domain/services/journalism/article_tags/find_article_tag_by_id_service.rs
+++ b/src/domain/services/journalism/article_tags/find_article_tag_by_id_service.rs
@@ -1,0 +1,90 @@
+use crate::domain::domain_entities::article_tag::ArticleTag;
+use crate::domain::repositories::article_tag_repository::ArticleTagRepositoryTrait;
+use crate::error::SamambaiaError;
+use crate::util::generate_service_internal_error;
+
+pub struct FindArticleTagByIdParams {
+    pub tag_id: u32,
+}
+
+#[derive(Debug)]
+pub struct FindArticleTagByIdResponse {
+    pub tag: Option<ArticleTag>,
+}
+
+pub struct FindArticleTagByIdService<ArticleTagRepository: ArticleTagRepositoryTrait> {
+    article_tag_repository: ArticleTagRepository,
+}
+
+impl<ArticleTagRepository: ArticleTagRepositoryTrait>
+    FindArticleTagByIdService<ArticleTagRepository>
+{
+    pub fn new(article_tag_repository: ArticleTagRepository) -> Self {
+        FindArticleTagByIdService {
+            article_tag_repository,
+        }
+    }
+
+    pub async fn exec(
+        &self,
+        params: FindArticleTagByIdParams,
+    ) -> Result<FindArticleTagByIdResponse, SamambaiaError> {
+        let tag = self
+            .article_tag_repository
+            .find_by_id(params.tag_id as i32)
+            .await
+            .map_err(|err| {
+                generate_service_internal_error(
+                    "Error occurred in Find Article Tag By ID service \
+                    when fetching tag from the database",
+                    err,
+                )
+            })?;
+
+        Ok(FindArticleTagByIdResponse { tag })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::domain::domain_entities::article_tag::ArticleTag;
+    use crate::tests::repositories::article_tag_repository::InMemoryArticleTagRepository;
+
+    #[tokio::test]
+    async fn it_should_find_existing_tags_by_ids() {
+        let tag_repository = InMemoryArticleTagRepository::default();
+
+        tag_repository
+            .tag_db
+            .lock()
+            .unwrap()
+            .push(ArticleTag::new_from_existing(1, "Bar".into()));
+
+        tag_repository
+            .tag_db
+            .lock()
+            .unwrap()
+            .push(ArticleTag::new_from_existing(2, "Foo".into()));
+
+        let sut = super::FindArticleTagByIdService::new(tag_repository);
+
+        let result = sut
+            .exec(super::FindArticleTagByIdParams { tag_id: 1 })
+            .await;
+
+        assert!(result.is_ok_and(|result| result.tag.is_some_and(|tag| tag.id() == 1)));
+    }
+
+    #[tokio::test]
+    async fn it_should_return_none_if_there_is_no_article_tag_with_given_id() {
+        let tag_repository = InMemoryArticleTagRepository::default();
+
+        let sut = super::FindArticleTagByIdService::new(tag_repository);
+
+        let result = sut
+            .exec(super::FindArticleTagByIdParams { tag_id: 1 })
+            .await;
+
+        assert!(result.is_ok_and(|result| result.tag.is_none()));
+    }
+}

--- a/src/domain/services/journalism/article_tags/mod.rs
+++ b/src/domain/services/journalism/article_tags/mod.rs
@@ -1,4 +1,5 @@
 pub mod create_article_tag_service;
 pub mod delete_article_tag_service;
 pub mod fetch_many_article_tags_service;
+pub mod find_article_tag_by_id_service;
 pub mod update_article_tag_service;

--- a/src/infra/http/controllers/admin/admin_article_tags_controller.rs
+++ b/src/infra/http/controllers/admin/admin_article_tags_controller.rs
@@ -1,15 +1,23 @@
-use actix_web::web::{self, Data, Query};
+use actix_session::Session;
+use actix_web::web::{self, Data, Json, Query, Redirect};
 use actix_web::{Either, HttpRequest};
 use inertia_rust::validators::InertiaValidateOrRedirect;
 use inertia_rust::{Inertia, InertiaFacade, InertiaProp, hashmap};
 
 use crate::core::pagination::DEFAULT_PER_PAGE;
-use crate::domain::factories::journalism::article_tags::fetch_many_article_tags_service_factory;
+use crate::domain::factories::journalism::article_tags::{
+    create_article_tag_service_factory,
+    fetch_many_article_tags_service_factory,
+};
+use crate::domain::services::journalism::article_tags::create_article_tag_service::CreateArticleTagParams;
 use crate::domain::services::journalism::article_tags::fetch_many_article_tags_service::FetchManyArticleTagsParams;
 use crate::error::IntoSamambaiaError;
-use crate::infra::http::controllers::AppResponseRedirect;
+use crate::infra::extensions::sessions::SessionHelpers;
 use crate::infra::http::controllers::controller::ControllerTrait;
+use crate::infra::http::controllers::{AppResponse, AppResponseRedirect};
+use crate::infra::http::dtos::create_article_tag::CreateArticleTagDto;
 use crate::infra::http::dtos::list_article_tags::ListArticleTagsDto;
+use crate::infra::http::middlewares::web::WebAuthUser;
 use crate::infra::http::middlewares::web::has_permission::{
     PermissionComparisonMode,
     WebHasPermissionMiddleware,
@@ -24,21 +32,40 @@ pub struct AdminArticleTagsController;
 impl ControllerTrait for AdminArticleTagsController {
     fn register(cfg: &mut actix_web::web::ServiceConfig) {
         cfg.service(
-            web::scope("/tags").route(
-                "",
-                web::get()
-                    .wrap(WebHasPermissionMiddleware::new(
-                        vec![RolePermissions::CreateArticle],
-                        PermissionComparisonMode::Any,
-                    ))
-                    .to(Self::manage_articles),
-            ),
+            web::scope("/tags")
+                .route(
+                    "",
+                    web::get()
+                        .wrap(WebHasPermissionMiddleware::new(
+                            vec![RolePermissions::CreateArticle],
+                            PermissionComparisonMode::Any,
+                        ))
+                        .to(Self::manage),
+                )
+                .route(
+                    "nova",
+                    web::get()
+                        .wrap(WebHasPermissionMiddleware::new(
+                            vec![RolePermissions::CreateArticleTag],
+                            PermissionComparisonMode::Any,
+                        ))
+                        .to(Self::create),
+                )
+                .route(
+                    "criar",
+                    web::post()
+                        .wrap(WebHasPermissionMiddleware::new(
+                            vec![RolePermissions::CreateArticleTag],
+                            PermissionComparisonMode::Any,
+                        ))
+                        .to(Self::store),
+                ),
         );
     }
 }
 
 impl AdminArticleTagsController {
-    async fn manage_articles(
+    async fn manage(
         req: HttpRequest,
         db_conn: Data<SeaService>,
         query: Query<ListArticleTagsDto>,
@@ -77,5 +104,44 @@ impl AdminArticleTagsController {
         .await
         .map_err(IntoSamambaiaError::into_samambaia_error)
         .map(Either::Left)
+    }
+
+    async fn create(req: HttpRequest) -> AppResponse {
+        Inertia::render(&req, "admin/articles/tags/new".into())
+            .await
+            .map_err(IntoSamambaiaError::into_samambaia_error)
+    }
+
+    async fn store(
+        req: HttpRequest,
+        body: Json<CreateArticleTagDto>,
+        db_conn: Data<SeaService>,
+        auth_user: WebAuthUser,
+    ) -> AppResponse<Redirect> {
+        let body = match body.validate_or_back(&req) {
+            Err(redirect) => return Ok(redirect),
+            Ok(body) => body,
+        };
+
+        let create_article_tag_service = create_article_tag_service_factory::exec(&db_conn);
+
+        let tag = create_article_tag_service
+            .exec(CreateArticleTagParams {
+                value: body.value,
+                user_role: auth_user.user.role().unwrap(),
+            })
+            .await?;
+
+        Session::flash_silently(
+            &req,
+            "createArticleTagSuccess",
+            format!(
+                "Tag {} criada com sucesso com ID {}!",
+                tag.value(),
+                tag.id()
+            ),
+        );
+
+        Ok(Inertia::back(&req))
     }
 }

--- a/src/infra/http/controllers/admin/admin_article_tags_controller.rs
+++ b/src/infra/http/controllers/admin/admin_article_tags_controller.rs
@@ -1,5 +1,5 @@
 use actix_session::Session;
-use actix_web::web::{self, Data, Json, Query, Redirect};
+use actix_web::web::{self, Data, Json, Path, Query, Redirect};
 use actix_web::{Either, HttpRequest};
 use inertia_rust::validators::InertiaValidateOrRedirect;
 use inertia_rust::{Inertia, InertiaFacade, InertiaProp, hashmap};
@@ -8,15 +8,20 @@ use crate::core::pagination::DEFAULT_PER_PAGE;
 use crate::domain::factories::journalism::article_tags::{
     create_article_tag_service_factory,
     fetch_many_article_tags_service_factory,
+    find_article_tag_by_id_service_factory,
+    update_article_tag_service_factory,
 };
 use crate::domain::services::journalism::article_tags::create_article_tag_service::CreateArticleTagParams;
 use crate::domain::services::journalism::article_tags::fetch_many_article_tags_service::FetchManyArticleTagsParams;
+use crate::domain::services::journalism::article_tags::find_article_tag_by_id_service::FindArticleTagByIdParams;
+use crate::domain::services::journalism::article_tags::update_article_tag_service::UpdateArticleTagParams;
 use crate::error::IntoSamambaiaError;
 use crate::infra::extensions::sessions::SessionHelpers;
 use crate::infra::http::controllers::controller::ControllerTrait;
 use crate::infra::http::controllers::{AppResponse, AppResponseRedirect};
 use crate::infra::http::dtos::create_article_tag::CreateArticleTagDto;
 use crate::infra::http::dtos::list_article_tags::ListArticleTagsDto;
+use crate::infra::http::dtos::update_article_tag::UpdateArticleTagDto;
 use crate::infra::http::middlewares::web::WebAuthUser;
 use crate::infra::http::middlewares::web::has_permission::{
     PermissionComparisonMode,
@@ -59,6 +64,24 @@ impl ControllerTrait for AdminArticleTagsController {
                             PermissionComparisonMode::Any,
                         ))
                         .to(Self::store),
+                )
+                .route(
+                    "{tag_id}/editar",
+                    web::get()
+                        .wrap(WebHasPermissionMiddleware::new(
+                            vec![RolePermissions::UpdateArticleTag],
+                            PermissionComparisonMode::Any,
+                        ))
+                        .to(Self::edit),
+                )
+                .route(
+                    "{tag_id}/atualizar",
+                    web::put()
+                        .wrap(WebHasPermissionMiddleware::new(
+                            vec![RolePermissions::UpdateArticleTag],
+                            PermissionComparisonMode::Any,
+                        ))
+                        .to(Self::update),
                 ),
         );
     }
@@ -140,6 +163,57 @@ impl AdminArticleTagsController {
                 tag.value(),
                 tag.id()
             ),
+        );
+
+        Ok(Inertia::back(&req))
+    }
+
+    async fn edit(req: HttpRequest, tag_id: Path<u32>, db_conn: Data<SeaService>) -> AppResponse {
+        let find_tag_service = find_article_tag_by_id_service_factory::exec(&db_conn);
+
+        let tag_id = tag_id.into_inner();
+        let tag = find_tag_service
+            .exec(FindArticleTagByIdParams { tag_id })
+            .await
+            .map(|response| response.tag.map(ArticleTagPresenter::to_http))?;
+
+        Inertia::render_with_props(
+            &req,
+            "admin/articles/tags/edit".into(),
+            hashmap![
+                "tag" => InertiaProp::data(tag)
+            ],
+        )
+        .await
+        .map_err(IntoSamambaiaError::into_samambaia_error)
+    }
+
+    async fn update(
+        req: HttpRequest,
+        tag_id: Path<u32>,
+        body: Json<UpdateArticleTagDto>,
+        db_conn: Data<SeaService>,
+        auth_user: WebAuthUser,
+    ) -> AppResponse<Redirect> {
+        let body = match body.validate_or_back(&req) {
+            Err(redirect) => return Ok(redirect),
+            Ok(body) => body,
+        };
+
+        let update_tag_service = update_article_tag_service_factory::exec(&db_conn);
+
+        let tag = update_tag_service
+            .exec(UpdateArticleTagParams {
+                tag_id: tag_id.into_inner() as i32,
+                user_role: auth_user.user.role().unwrap(),
+                value: body.value,
+            })
+            .await?;
+
+        Session::flash_silently(
+            &req,
+            "updateArticleTagSuccess",
+            format!("Tag {} atualizada com sucesso!", tag.value()),
         );
 
         Ok(Inertia::back(&req))

--- a/src/infra/http/controllers/admin/admin_article_tags_controller.rs
+++ b/src/infra/http/controllers/admin/admin_article_tags_controller.rs
@@ -1,0 +1,81 @@
+use actix_web::web::{self, Data, Query};
+use actix_web::{Either, HttpRequest};
+use inertia_rust::validators::InertiaValidateOrRedirect;
+use inertia_rust::{Inertia, InertiaFacade, InertiaProp, hashmap};
+
+use crate::core::pagination::DEFAULT_PER_PAGE;
+use crate::domain::factories::journalism::article_tags::fetch_many_article_tags_service_factory;
+use crate::domain::services::journalism::article_tags::fetch_many_article_tags_service::FetchManyArticleTagsParams;
+use crate::error::IntoSamambaiaError;
+use crate::infra::http::controllers::AppResponseRedirect;
+use crate::infra::http::controllers::controller::ControllerTrait;
+use crate::infra::http::dtos::list_article_tags::ListArticleTagsDto;
+use crate::infra::http::middlewares::web::has_permission::{
+    PermissionComparisonMode,
+    WebHasPermissionMiddleware,
+};
+use crate::infra::http::presenters::article_tag::ArticleTagPresenter;
+use crate::infra::http::presenters::presenter::PresenterTrait;
+use crate::infra::sea::sea_service::SeaService;
+use crate::util::RolePermissions;
+
+pub struct AdminArticleTagsController;
+
+impl ControllerTrait for AdminArticleTagsController {
+    fn register(cfg: &mut actix_web::web::ServiceConfig) {
+        cfg.service(
+            web::scope("/tags").route(
+                "",
+                web::get()
+                    .wrap(WebHasPermissionMiddleware::new(
+                        vec![RolePermissions::CreateArticle],
+                        PermissionComparisonMode::Any,
+                    ))
+                    .to(Self::manage_articles),
+            ),
+        );
+    }
+}
+
+impl AdminArticleTagsController {
+    async fn manage_articles(
+        req: HttpRequest,
+        db_conn: Data<SeaService>,
+        query: Query<ListArticleTagsDto>,
+    ) -> AppResponseRedirect {
+        let query = match query
+            .into_inner()
+            .validate_or_back(&req)
+            .map_err(Either::Right)
+        {
+            Ok(query) => query,
+            Err(redirect_back) => return Ok(redirect_back),
+        };
+
+        let find_articles_service = fetch_many_article_tags_service_factory::exec(&db_conn);
+
+        let per_page = query.per_page.unwrap_or(DEFAULT_PER_PAGE);
+
+        let tags = find_articles_service
+            .exec(FetchManyArticleTagsParams {
+                page: query.page,
+                per_page: Some(per_page as u32),
+                query: query.value,
+            })
+            .await?;
+
+        let tags =
+            ArticleTagPresenter::to_json_paginated_wrapper(tags.data, tags.pagination, per_page);
+
+        Inertia::render_with_props(
+            &req,
+            "admin/articles/tags/index".into(),
+            hashmap![
+                "tags" => InertiaProp::data(tags)
+            ],
+        )
+        .await
+        .map_err(IntoSamambaiaError::into_samambaia_error)
+        .map(Either::Left)
+    }
+}

--- a/src/infra/http/controllers/admin/admin_article_tags_controller.rs
+++ b/src/infra/http/controllers/admin/admin_article_tags_controller.rs
@@ -7,15 +7,17 @@ use inertia_rust::{Inertia, InertiaFacade, InertiaProp, hashmap};
 use crate::core::pagination::DEFAULT_PER_PAGE;
 use crate::domain::factories::journalism::article_tags::{
     create_article_tag_service_factory,
+    delete_article_tag_service_factory,
     fetch_many_article_tags_service_factory,
     find_article_tag_by_id_service_factory,
     update_article_tag_service_factory,
 };
 use crate::domain::services::journalism::article_tags::create_article_tag_service::CreateArticleTagParams;
+use crate::domain::services::journalism::article_tags::delete_article_tag_service::DeleteArticleTagParams;
 use crate::domain::services::journalism::article_tags::fetch_many_article_tags_service::FetchManyArticleTagsParams;
 use crate::domain::services::journalism::article_tags::find_article_tag_by_id_service::FindArticleTagByIdParams;
 use crate::domain::services::journalism::article_tags::update_article_tag_service::UpdateArticleTagParams;
-use crate::error::IntoSamambaiaError;
+use crate::error::{IntoSamambaiaError, SamambaiaError};
 use crate::infra::extensions::sessions::SessionHelpers;
 use crate::infra::http::controllers::controller::ControllerTrait;
 use crate::infra::http::controllers::{AppResponse, AppResponseRedirect};
@@ -82,6 +84,15 @@ impl ControllerTrait for AdminArticleTagsController {
                             PermissionComparisonMode::Any,
                         ))
                         .to(Self::update),
+                )
+                .route(
+                    "{tag_id}/apagar",
+                    web::delete()
+                        .wrap(WebHasPermissionMiddleware::new(
+                            vec![RolePermissions::DeleteArticleTag],
+                            PermissionComparisonMode::Any,
+                        ))
+                        .to(Self::delete),
                 ),
         );
     }
@@ -217,5 +228,34 @@ impl AdminArticleTagsController {
         );
 
         Ok(Inertia::back(&req))
+    }
+
+    async fn delete(
+        req: HttpRequest,
+        tag_id: Path<u32>,
+        auth_user: WebAuthUser,
+        db_conn: Data<SeaService>,
+    ) -> Redirect {
+        let service = delete_article_tag_service_factory::exec(&db_conn);
+
+        if let Err(err) = service
+            .exec(DeleteArticleTagParams {
+                tag_id: tag_id.into_inner() as i32,
+                user_role: auth_user.user.role().as_ref().unwrap(),
+            })
+            .await
+        {
+            return Inertia::back_with_errors(
+                &req,
+                hashmap!["error" => match err {
+                    SamambaiaError::Unauthorized(msg) => msg.to_string().into(),
+                    _ => "Não foi possível deletar esta tag. Contate um desenvolvedor.".to_string().into()
+                }],
+            );
+        }
+
+        Session::flash_silently(&req, "deleteArticleTagSuccess", "Tag deletada com sucesso.");
+
+        Inertia::back(&req)
     }
 }

--- a/src/infra/http/controllers/admin/mod.rs
+++ b/src/infra/http/controllers/admin/mod.rs
@@ -1,2 +1,3 @@
+pub mod admin_article_tags_controller;
 pub mod admin_articles_controller;
 pub mod admin_home_controller;

--- a/src/infra/http/dtos/create_article_tag.rs
+++ b/src/infra/http/dtos/create_article_tag.rs
@@ -3,6 +3,6 @@ use validator::Validate;
 
 #[derive(Serialize, Deserialize, Validate)]
 pub struct CreateArticleTagDto {
-    #[validate(length(min = 1, message = "Article tag can't be empty."))]
+    #[validate(length(min = 1, message = "Uma tag não pode ser um texto vazio."))]
     pub value: String,
 }

--- a/src/infra/http/dtos/list_article_tags.rs
+++ b/src/infra/http/dtos/list_article_tags.rs
@@ -4,7 +4,6 @@ use validator::Validate;
 #[derive(Serialize, Deserialize, Validate)]
 pub struct ListArticleTagsDto {
     pub page: Option<u32>,
-    #[serde(rename = "perPage")]
     pub per_page: Option<u8>,
     pub value: Option<String>,
 }

--- a/src/infra/http/dtos/update_article_tag.rs
+++ b/src/infra/http/dtos/update_article_tag.rs
@@ -3,6 +3,9 @@ use validator::Validate;
 
 #[derive(Serialize, Deserialize, Validate)]
 pub struct UpdateArticleTagDto {
-    #[validate(length(min = 1, message = "Article tag value must be at least one char long."))]
+    #[validate(length(
+        min = 1,
+        message = "O conteúdo de uma tag de notícia precisa ter pelo menos 1 caractere."
+    ))]
     pub value: Option<String>,
 }

--- a/src/infra/http/routes/web.rs
+++ b/src/infra/http/routes/web.rs
@@ -29,6 +29,7 @@ use crate::configs::file_sessions::FileSessionStore;
 use crate::core::pagination::DEFAULT_PER_PAGE;
 use crate::domain::factories::announcements::fetch_many_announcements_service_factory;
 use crate::domain::services::announcements::fetch_many_announcements_service::FetchManyAnnouncementsParams;
+use crate::infra::http::controllers::admin::admin_article_tags_controller::AdminArticleTagsController;
 use crate::infra::http::controllers::admin::admin_articles_controller::AdminArticlesController;
 use crate::infra::http::controllers::admin::admin_home_controller::AdminHomeController;
 use crate::infra::http::controllers::controller::ControllerTrait;
@@ -150,6 +151,7 @@ impl RouteTrait for WebRoutes {
                             PermissionComparisonMode::All,
                         ))
                         .wrap(WebAuthUserMiddleware)
+                        .configure(AdminArticleTagsController::register)
                         .configure(AdminArticlesController::register)
                         // needs to be the last, since captures everything else by having "" in its scope.
                         .configure(AdminHomeController::register)

--- a/src/infra/sea/repositories/sea_article_repository.rs
+++ b/src/infra/sea/repositories/sea_article_repository.rs
@@ -134,7 +134,6 @@ impl ArticleRepositoryTrait for SeaArticleRepository<'_> {
     async fn find_by_id(&self, id: Uuid) -> Result<Option<Article>, Box<dyn Error>> {
         let mut article = ArticleEntity::find_by_id(id)
             .find_with_related(entities::article_tag::Entity)
-            .limit(1)
             .all(&self.sea_service.db)
             .await?;
 
@@ -158,7 +157,6 @@ impl ArticleRepositoryTrait for SeaArticleRepository<'_> {
         let mut article = ArticleEntity::find()
             .filter(ArticleColumn::Slug.eq(slug.to_string()))
             .find_with_related(entities::article_tag::Entity)
-            .limit(1)
             .all(&self.sea_service.db)
             .await?;
 

--- a/www/components/admin/chip/index.tsx
+++ b/www/components/admin/chip/index.tsx
@@ -9,7 +9,7 @@ type ChipProps = {
   size: "sm";
 };
 
-export const Chip = memo(({ text, size, className, icon: I }: ChipProps) => {
+export const AdminChip = memo(({ text, size, className, icon: I }: ChipProps) => {
   return (
     <div
       className={clsx(

--- a/www/components/chip.tsx
+++ b/www/components/chip.tsx
@@ -1,0 +1,22 @@
+import { Slot } from "@radix-ui/react-slot";
+import clsx from "clsx";
+import type { PropsWithChildren } from "react";
+
+type Props = PropsWithChildren & {
+  asChild?: boolean;
+};
+
+export function Chip({ asChild, children }: Props) {
+  const Element = asChild ? Slot : "span";
+
+  return (
+    <Element
+      className={clsx(
+        "text-white font-medium text-sm leading-normal px-2 py-0.5 rounded-sm cursor-default",
+        "bg-blue-500 ring-inset ring-2 ring-blue-800 shadow-[inset_0_4px_0_0] shadow-white/50",
+        "text-shadow-[0px_-1px_0] text-shadow-blue-800",
+      )}>
+      {children}
+    </Element>
+  );
+}

--- a/www/config/routes.ts
+++ b/www/config/routes.ts
@@ -36,6 +36,7 @@ export const routes = {
       edit: (tagId: ArticleTag["id"]) => `/gremio/tags/${tagId}/editar`,
       delete: (tagId: ArticleTag["id"]) => `/gremio/tags/${tagId}/apagar`,
       storeNewTag: "/gremio/tags/criar",
+      updateChanges: (tagId: ArticleTag["id"]) => `/gremio/tags/${tagId}/atualizar`,
     },
   },
 } as const;

--- a/www/config/routes.ts
+++ b/www/config/routes.ts
@@ -1,4 +1,5 @@
 import type { Article } from "@/types/article";
+import type { ArticleTag } from "@/types/article-tag";
 
 export const routes = {
   tools: {
@@ -28,6 +29,13 @@ export const routes = {
       storeNewArticle: "/gremio/noticias/criar",
       toggleApproved: (articleId: string) => `/gremio/noticias/${articleId}/alterar-aprovado`,
       delete: (articleId: Article["id"]) => `/gremio/noticias/${articleId}/apagar`,
+    },
+    tags: {
+      list: "/gremio/tags",
+      create: "/gremio/tags/nova",
+      edit: (tagId: ArticleTag["id"]) => `/gremio/tags/${tagId}/editar`,
+      delete: (tagId: ArticleTag["id"]) => `/gremio/tags/${tagId}/apagar`,
+      storeNewTag: "/gremio/tags/criar",
     },
   },
 } as const;

--- a/www/pages/admin/articles/tags/edit.tsx
+++ b/www/pages/admin/articles/tags/edit.tsx
@@ -1,0 +1,118 @@
+import type { PageProps } from "@inertiajs/core/types";
+import { router, useForm } from "@inertiajs/react";
+import { PlusIcon } from "@phosphor-icons/react/dist/ssr/Plus";
+import { SpinnerIcon } from "@phosphor-icons/react/dist/ssr/Spinner";
+import type { FormEvent, PropsWithChildren } from "react";
+import { toast } from "react-toastify";
+import { AdminAlert } from "@/components/alert/admin-alert";
+import { AdminButton } from "@/components/button/admin-button";
+import Form from "@/components/form/admin-form";
+import { Head } from "@/components/head";
+import Header from "@/components/header";
+import { Main } from "@/components/main";
+import { routes } from "@/config/routes";
+import type { ArticleTag } from "@/types/article-tag";
+
+type Props = PageProps & {
+  tag: ArticleTag | null;
+};
+
+type CreateTagForm = {
+  value?: string;
+};
+
+export default function AdminEditArticleTagPage({ tag }: Props) {
+  const { data, setData, errors, clearErrors, processing, put, transform } = useForm<CreateTagForm>(
+    { value: tag?.value },
+  );
+
+  if (!tag) {
+    return (
+      <Wrapper title="Tag não encontrada">
+        <AdminAlert type="warning" message="A tag especificada não foi encontrada." />
+      </Wrapper>
+    );
+  }
+
+  transform((data) => {
+    if (data.value === tag.value) delete data.value;
+    return data;
+  });
+
+  const handleCreateTag = (e: FormEvent) => {
+    e.preventDefault();
+    clearErrors();
+    put(routes.admin.tags.updateChanges(tag.id), {
+      onSuccess: (page) => {
+        toast.success(page.props.flash.updateArticleTagSuccess, { autoClose: 3000 });
+        router.visit(routes.admin.tags.list);
+      },
+      onError: (errors) => {
+        if (!("error" in errors)) return;
+        toast.error("Não foi possível criar a nova tag. Por favor, contate um desenvolvedor.");
+        console.error(errors.error);
+      },
+    });
+  };
+
+  return (
+    <Wrapper title={`Editando tag ${tag.value}`}>
+      <Form.Root onSubmit={handleCreateTag} className="flex flex-col gap-3">
+        <Form.Input
+          label="Valor"
+          placeholder="Fã-site"
+          name="value"
+          required
+          validationError={errors.value}
+          onInput={(e) => setData({ value: e.currentTarget.value })}
+          defaultValue={data.value}
+        />
+
+        <div className="mt-3 flex items-center gap-1.5">
+          <AdminButton
+            variant="default"
+            theme="success"
+            size="lg"
+            type="submit"
+            disabled={processing}>
+            {processing ? (
+              <>
+                <SpinnerIcon size={16} weight="bold" className="animate-spin" />
+                Salvando...
+              </>
+            ) : (
+              <>
+                <PlusIcon size={16} weight="bold" />
+                Salvar
+              </>
+            )}
+          </AdminButton>
+          <AdminButton
+            onClick={() => window.history.back()}
+            size="lg"
+            variant="ghost"
+            type="button">
+            Cancelar
+          </AdminButton>
+        </div>
+      </Form.Root>
+    </Wrapper>
+  );
+}
+
+function Wrapper({ children, title }: PropsWithChildren<{ title: string }>) {
+  return (
+    <>
+      <Head admin title={title} />
+
+      <Main admin>
+        <Header.Root className="mb-8">
+          <Header.Title>{title}</Header.Title>
+          <Header.Divisor />
+        </Header.Root>
+
+        {children}
+      </Main>
+    </>
+  );
+}

--- a/www/pages/admin/articles/tags/index.tsx
+++ b/www/pages/admin/articles/tags/index.tsx
@@ -1,0 +1,72 @@
+import type { PageProps, SharedPageProps } from "@inertiajs/core/types";
+import type { PropsWithChildren } from "react";
+import { Alert } from "@/components/alert";
+import Button from "@/components/button";
+import { Head } from "@/components/head";
+import Header from "@/components/header";
+import { Main } from "@/components/main";
+import { routes } from "@/config/routes";
+import { useCanSee } from "@/hooks/useCanSee";
+import type { ArticleTag } from "@/types/article-tag";
+import { Permission } from "@/types/auth";
+import type { Paginated } from "@/types/pagination";
+import { ArticleTagListCard } from "@/ui/admin/article-tag-list-card";
+import TableHeader from "@/ui/admin/paginated-table-header";
+
+type AdminArticleTagsPageProps = SharedPageProps &
+  PageProps & {
+    tags: Paginated<ArticleTag[]>;
+  };
+
+export default function AdminArticleTagsHome({ tags }: AdminArticleTagsPageProps) {
+  if (tags.pagination.totalItems === 0) {
+    return (
+      <Wrapper>
+        <Alert admin type="info" message="Ainda não existem tags de notícias." />
+      </Wrapper>
+    );
+  }
+
+  return (
+    <Wrapper>
+      <TableHeader.Root className="mb-4">
+        <TableHeader.Count
+          currentPage={tags.pagination.currentPage}
+          itemsInCurrentPage={tags.data.length}
+          itemsPerPage={tags.pagination.itemsPerPage}
+          totalItems={tags.pagination.totalItems}
+          subject="tags"
+        />
+      </TableHeader.Root>
+      <div className="flex flex-col gap-1">
+        {tags.data.map((tag) => (
+          <ArticleTagListCard key={`admin-article-tag-list-${tag.id}`} {...tag} />
+        ))}
+      </div>
+    </Wrapper>
+  );
+}
+
+function Wrapper({ children }: PropsWithChildren) {
+  const userCanCreateTags = useCanSee(Permission.CreateArticleTag);
+  return (
+    <>
+      <Head admin title="Tags" />
+      <Main admin>
+        <Header.Root className="mb-8">
+          <Header.Title>Tags de notícias</Header.Title>
+          <Header.Divisor />
+          <Header.Actions>
+            {userCanCreateTags && (
+              <Button admin asLink href={routes.admin.tags.create} variant="default">
+                Criar nova tag
+              </Button>
+            )}
+          </Header.Actions>
+        </Header.Root>
+
+        {children}
+      </Main>
+    </>
+  );
+}

--- a/www/pages/admin/articles/tags/new.tsx
+++ b/www/pages/admin/articles/tags/new.tsx
@@ -1,5 +1,4 @@
 import { router, useForm } from "@inertiajs/react";
-import { ArrowLeftIcon } from "@phosphor-icons/react/dist/ssr/ArrowLeft";
 import { PlusIcon } from "@phosphor-icons/react/dist/ssr/Plus";
 import { SpinnerIcon } from "@phosphor-icons/react/dist/ssr/Spinner";
 import type { FormEvent } from "react";
@@ -73,8 +72,11 @@ export default function AdminCreateArticleTagPage() {
                 </>
               )}
             </AdminButton>
-            <AdminButton onClick={() => window.history.back()} size="lg" type="button">
-              <ArrowLeftIcon size={16} weight="bold" />
+            <AdminButton
+              onClick={() => window.history.back()}
+              size="lg"
+              variant="ghost"
+              type="button">
               Voltar
             </AdminButton>
           </div>

--- a/www/pages/admin/articles/tags/new.tsx
+++ b/www/pages/admin/articles/tags/new.tsx
@@ -1,0 +1,85 @@
+import { router, useForm } from "@inertiajs/react";
+import { ArrowLeftIcon } from "@phosphor-icons/react/dist/ssr/ArrowLeft";
+import { PlusIcon } from "@phosphor-icons/react/dist/ssr/Plus";
+import { SpinnerIcon } from "@phosphor-icons/react/dist/ssr/Spinner";
+import type { FormEvent } from "react";
+import { toast } from "react-toastify";
+import { AdminButton } from "@/components/button/admin-button";
+import Form from "@/components/form/admin-form";
+import { Head } from "@/components/head";
+import Header from "@/components/header";
+import { Main } from "@/components/main";
+import { routes } from "@/config/routes";
+
+type CreateTagForm = {
+  value: string;
+};
+
+export default function AdminCreateArticleTagPage() {
+  const { setData, errors, clearErrors, processing, post } = useForm<CreateTagForm>();
+
+  const handleCreateTag = (e: FormEvent) => {
+    e.preventDefault();
+    clearErrors();
+    post(routes.admin.tags.storeNewTag, {
+      onSuccess: (page) => {
+        toast.success(page.props.flash.createArticleTagSuccess, { autoClose: 3000 });
+        router.visit(routes.admin.tags.list);
+      },
+      onError: (errors) => {
+        if (!("error" in errors)) return;
+        toast.error("Não foi possível criar a nova tag. Por favor, contate um desenvolvedor.");
+        console.error(errors.error);
+      },
+    });
+  };
+
+  return (
+    <>
+      <Head admin title="Nova tag de notícia" />
+
+      <Main admin>
+        <Header.Root className="mb-8">
+          <Header.Title>Criar tag de notícia</Header.Title>
+          <Header.Divisor />
+        </Header.Root>
+
+        <Form.Root onSubmit={handleCreateTag} className="flex flex-col gap-3">
+          <Form.Input
+            label="Valor"
+            placeholder="Fã-site"
+            name="value"
+            required
+            validationError={errors.value}
+            onInput={(e) => setData({ value: e.currentTarget.value })}
+          />
+
+          <div className="mt-3 flex items-center gap-1.5">
+            <AdminButton
+              variant="default"
+              theme="success"
+              size="lg"
+              type="submit"
+              disabled={processing}>
+              {processing ? (
+                <>
+                  <SpinnerIcon size={16} weight="bold" className="animate-spin" />
+                  Criando...
+                </>
+              ) : (
+                <>
+                  <PlusIcon size={16} weight="bold" />
+                  Criar
+                </>
+              )}
+            </AdminButton>
+            <AdminButton onClick={() => window.history.back()} size="lg" type="button">
+              <ArrowLeftIcon size={16} weight="bold" />
+              Voltar
+            </AdminButton>
+          </div>
+        </Form.Root>
+      </Main>
+    </>
+  );
+}

--- a/www/styles/app.css
+++ b/www/styles/app.css
@@ -233,6 +233,15 @@
   }
 }
 
+@utility no-scrollbar {
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
 @utility w-full-mx {
   width: calc(100% - 48px);
 }

--- a/www/styles/app.css
+++ b/www/styles/app.css
@@ -26,6 +26,7 @@
   --color-blue-500: #0997e8;
   --color-blue-600: #097ee3;
   --color-blue-700: #0075ff;
+  --color-blue-800: #0044e2;
 
   --color-green-300: #14ff48;
   --color-green-500: #27c13f;

--- a/www/ui/admin/article-list-card/index.tsx
+++ b/www/ui/admin/article-list-card/index.tsx
@@ -66,15 +66,15 @@ export const ArticleListCard = memo(
           {title}
         </span>
 
-        <div className="max-w-3/5 flex gap-2 items-center justify-end grow">
-          <div className="overflow-x-auto no-scrollbar snap-mandatory snap-x flex gap-2 items-center">
+        <div className="max-w-3/5 flex gap-2 items-center justify-end">
+          <div className="overflow-x-auto no-scrollbar snap-mandatory snap-x flex gap-2 items-center rounded-full">
             {tags.map((tag) => (
               <Chip
                 key={`article-list-card-${id}-tag-${tag.id}`}
                 icon={TagIcon}
                 text={tag.value}
                 size="sm"
-                className="whitespace-nowrap snap-center snap-normal"
+                className="whitespace-nowrap snap-center snap-normal bg-purple-300/10"
               />
             ))}
           </div>
@@ -94,7 +94,7 @@ export const ArticleListCard = memo(
           />
         </div>
 
-        <div className="flex items-center justify-end gap-1 grow max-w-20">
+        <div className="flex items-center justify-end gap-1 max-w-20 shrink-0">
           <DeleteArticleButton articleId={id} articleTitle={title} />
 
           {(auth?.user.id === author.id || can(auth?.permissions, Permission.UpdateArticle)) && (

--- a/www/ui/admin/article-list-card/index.tsx
+++ b/www/ui/admin/article-list-card/index.tsx
@@ -62,19 +62,24 @@ export const ArticleListCard = memo(
 
     return (
       <article className="admin-list-card">
-        <span className="flex-1/2 text-sm line-clamp-1 text-gray-800">{title}</span>
+        <span title={title} className="flex-1/2 text-sm line-clamp-1 text-gray-800">
+          {title}
+        </span>
 
-        <div className="flex gap-2 items-center justify-end grow">
+        <div className="max-w-3/5 flex gap-2 items-center justify-end grow">
+          <div className="overflow-x-auto no-scrollbar snap-mandatory snap-x flex gap-2 items-center">
+            {tags.map((tag) => (
+              <Chip
+                key={`article-list-card-${id}-tag-${tag.id}`}
+                icon={TagIcon}
+                text={tag.value}
+                size="sm"
+                className="whitespace-nowrap snap-center snap-normal"
+              />
+            ))}
+          </div>
+
           <Chip icon={UserIcon} text={author.nickname} size="sm" />
-
-          {tags.map((tag) => (
-            <Chip
-              key={`article-list-card-${id}-tag-${tag.id}`}
-              icon={TagIcon}
-              text={tag.value}
-              size="sm"
-            />
-          ))}
 
           <Chip
             icon={CalendarBlankIcon}

--- a/www/ui/admin/article-list-card/index.tsx
+++ b/www/ui/admin/article-list-card/index.tsx
@@ -7,7 +7,7 @@ import { UserIcon } from "@phosphor-icons/react/dist/ssr/User";
 import { memo, useCallback, useState } from "react";
 import { toast } from "react-toastify";
 
-import { Chip } from "@/components/chip";
+import { AdminChip } from "@/components/admin/chip";
 import { IconButton } from "@/components/icon-button";
 import { routes } from "@/config/routes";
 import type { ArticlePreview } from "@/types/article-preview";
@@ -69,7 +69,7 @@ export const ArticleListCard = memo(
         <div className="max-w-3/5 flex gap-2 items-center justify-end">
           <div className="overflow-x-auto no-scrollbar snap-mandatory snap-x flex gap-2 items-center rounded-full">
             {tags.map((tag) => (
-              <Chip
+              <AdminChip
                 key={`article-list-card-${id}-tag-${tag.id}`}
                 icon={TagIcon}
                 text={tag.value}
@@ -79,9 +79,9 @@ export const ArticleListCard = memo(
             ))}
           </div>
 
-          <Chip icon={UserIcon} text={author.nickname} size="sm" />
+          <AdminChip icon={UserIcon} text={author.nickname} size="sm" />
 
-          <Chip
+          <AdminChip
             icon={CalendarBlankIcon}
             text={new Date(createdAt).toLocaleDateString("pt-BR")}
             size="sm"

--- a/www/ui/admin/article-tag-list-card/delete-article-tag-button.tsx
+++ b/www/ui/admin/article-tag-list-card/delete-article-tag-button.tsx
@@ -21,8 +21,7 @@ export function DeleteArticleTagButton({ tagId, tagValue }: Props) {
       preserveScroll: true,
       onSuccess: () => toast.success(`Tag ${tagValue} removida com sucesso.`),
       onError: (errors) => {
-        toast.error(`Não foi possível remover a tag ${tagValue}.`);
-        if ("error" in errors) console.error(errors.error);
+        if ("error" in errors) toast.error(errors.error);
       },
       onStart: () => setIsProcessing(true),
       onFinish: () => setIsProcessing(false),
@@ -52,14 +51,16 @@ export function DeleteArticleTagButton({ tagId, tagValue }: Props) {
           <hr />
 
           <div className="flex items-center justify-end gap-2">
-            <AdminButton
-              variant="default"
-              theme="danger"
-              size="lg"
-              disabled={isProcessing}
-              onClick={handleDeleteArticleTag}>
-              {isProcessing ? "Apagando..." : "Apagar"}
-            </AdminButton>
+            <Dialog.Close asChild>
+              <AdminButton
+                variant="default"
+                theme="danger"
+                size="lg"
+                disabled={isProcessing}
+                onClick={handleDeleteArticleTag}>
+                {isProcessing ? "Apagando..." : "Apagar"}
+              </AdminButton>
+            </Dialog.Close>
             <Dialog.Close asChild>
               <AdminButton size="lg" disabled={isProcessing}>
                 Deixa baixo

--- a/www/ui/admin/article-tag-list-card/delete-article-tag-button.tsx
+++ b/www/ui/admin/article-tag-list-card/delete-article-tag-button.tsx
@@ -1,0 +1,73 @@
+import { router } from "@inertiajs/react";
+import { TrashIcon } from "@phosphor-icons/react/dist/ssr/Trash";
+import { useState } from "react";
+import { toast } from "react-toastify";
+import Dialog from "@/components/admin/dialog";
+import { AdminButton } from "@/components/button/admin-button";
+import { AdminIconButton } from "@/components/icon-button/admin-icon-button";
+import { routes } from "@/config/routes";
+import type { ArticleTag } from "@/types/article-tag";
+
+type Props = {
+  tagId: ArticleTag["id"];
+  tagValue: string;
+};
+
+export function DeleteArticleTagButton({ tagId, tagValue }: Props) {
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const handleDeleteArticleTag = () => {
+    router.delete(routes.admin.tags.delete(tagId), {
+      preserveScroll: true,
+      onSuccess: () => toast.success(`Tag ${tagValue} removida com sucesso.`),
+      onError: (errors) => {
+        toast.error(`Não foi possível remover a tag ${tagValue}.`);
+        if ("error" in errors) console.error(errors.error);
+      },
+      onStart: () => setIsProcessing(true),
+      onFinish: () => setIsProcessing(false),
+    });
+  };
+
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger asChild>
+        <AdminIconButton size="sm" theme="danger" variant="ghost" icon={TrashIcon} />
+      </Dialog.Trigger>
+
+      <Dialog.Content>
+        <Dialog.Header
+          title={`Apagar tag "${tagValue}"`}
+          description={`Formulário para apagar a notícia ${tagValue} de ID ${tagId}.`}
+        />
+
+        <Dialog.Container className="flex flex-col gap-4 text-gray-800">
+          <p className="font-light">
+            Ao apagar essa tag, você se responsabiliza pela sua remoção e desassociação com todas as
+            notícias que estão relacionadas com ela. Essa ação é <strong>irreversível</strong>. Ao
+          </p>
+
+          <p className="font-light">Você tem certeza do que está fazendo?</p>
+
+          <hr />
+
+          <div className="flex items-center justify-end gap-2">
+            <AdminButton
+              variant="default"
+              theme="danger"
+              size="lg"
+              disabled={isProcessing}
+              onClick={handleDeleteArticleTag}>
+              {isProcessing ? "Apagando..." : "Apagar"}
+            </AdminButton>
+            <Dialog.Close asChild>
+              <AdminButton size="lg" disabled={isProcessing}>
+                Deixa baixo
+              </AdminButton>
+            </Dialog.Close>
+          </div>
+        </Dialog.Container>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/www/ui/admin/article-tag-list-card/index.tsx
+++ b/www/ui/admin/article-tag-list-card/index.tsx
@@ -1,0 +1,35 @@
+import { usePage } from "@inertiajs/react";
+import { PencilSimpleIcon } from "@phosphor-icons/react/dist/ssr/PencilSimple";
+import { memo } from "react";
+import { AdminIconButton } from "@/components/icon-button/admin-icon-button";
+import type { ArticleTag } from "@/types/article-tag";
+import { Permission } from "@/types/auth";
+import { can } from "@/utils/can";
+import { DeleteArticleTagButton } from "./delete-article-tag-button";
+
+type Props = ArticleTag;
+
+export const ArticleTagListCard = memo(({ id, value }: Props) => {
+  const auth = usePage().props.auth;
+  const userCanEditTag = can(auth?.permissions, Permission.UpdateArticleTag);
+
+  return (
+    <li className="admin-list-card list-none">
+      <span className="flex-1/2 text-sm line-clamp-1 text-gray-800">{value}</span>
+      <div className="flex items-center justify-end gap-1 grow max-w-20">
+        <DeleteArticleTagButton tagId={id} tagValue={value} />
+
+        {userCanEditTag && (
+          <AdminIconButton
+            size="sm"
+            variant="ghost"
+            theme="warn"
+            icon={PencilSimpleIcon}
+            asLink
+            href={`/gremio/noticias/${id}/editar`}
+          />
+        )}
+      </div>
+    </li>
+  );
+});

--- a/www/ui/admin/article-tag-list-card/index.tsx
+++ b/www/ui/admin/article-tag-list-card/index.tsx
@@ -13,12 +13,13 @@ type Props = ArticleTag;
 export const ArticleTagListCard = memo(({ id, value }: Props) => {
   const auth = usePage().props.auth;
   const userCanEditTag = can(auth?.permissions, Permission.UpdateArticleTag);
+  const userCanDeleteTag = can(auth?.permissions, Permission.DeleteArticleTag);
 
   return (
     <li className="admin-list-card list-none">
       <span className="flex-1/2 text-sm line-clamp-1 text-gray-800">{value}</span>
       <div className="flex items-center justify-end gap-1 grow max-w-20">
-        <DeleteArticleTagButton tagId={id} tagValue={value} />
+        {userCanDeleteTag && <DeleteArticleTagButton tagId={id} tagValue={value} />}
 
         {userCanEditTag && (
           <AdminIconButton

--- a/www/ui/admin/article-tag-list-card/index.tsx
+++ b/www/ui/admin/article-tag-list-card/index.tsx
@@ -2,6 +2,7 @@ import { usePage } from "@inertiajs/react";
 import { PencilSimpleIcon } from "@phosphor-icons/react/dist/ssr/PencilSimple";
 import { memo } from "react";
 import { AdminIconButton } from "@/components/icon-button/admin-icon-button";
+import { routes } from "@/config/routes";
 import type { ArticleTag } from "@/types/article-tag";
 import { Permission } from "@/types/auth";
 import { can } from "@/utils/can";
@@ -26,7 +27,7 @@ export const ArticleTagListCard = memo(({ id, value }: Props) => {
             theme="warn"
             icon={PencilSimpleIcon}
             asLink
-            href={`/gremio/noticias/${id}/editar`}
+            href={routes.admin.tags.edit(id)}
           />
         )}
       </div>

--- a/www/ui/admin/sidebar/index.tsx
+++ b/www/ui/admin/sidebar/index.tsx
@@ -20,7 +20,7 @@ import { SidebarSectionTitle } from "./sidebar-section-title";
 
 export const SidebarMenu = memo(() => {
   return (
-    <aside className={clsx("[grid-area:_aside] ml-6 w-80")}>
+    <aside className={clsx("[grid-area:aside] ml-6 w-80")}>
       <div className="sticky top-6 max-h-full">
         <Accordion.Root type="multiple" className="flex flex-col gap-2">
           <SidebarMenuLink icon={HouseIcon} href="/gremio" label="Home" />
@@ -34,11 +34,17 @@ export const SidebarMenu = memo(() => {
             requires={{
               permissions: ["CreateArticle", "DeleteArticle", "UpdateArticle", "ApproveArticle"],
             }}>
-            <SidebarMenuItem href="/gremio/noticias" label="Gerenciar notícias" />
+            <SidebarMenuItem href={routes.admin.articles.list} label="Gerenciar notícias" />
+            <SidebarMenuItem href={routes.admin.tags.list} label="Gerenciar tags de notícias" />
             <SidebarMenuItem
               href={routes.admin.articles.create}
               label="Nova notícia"
               requires="CreateArticle"
+            />
+            <SidebarMenuItem
+              href={routes.admin.tags.create}
+              label="Nova tag"
+              requires="CreateArticleTag"
             />
           </SidebarMenuSection>
 

--- a/www/ui/admin/sidebar/index.tsx
+++ b/www/ui/admin/sidebar/index.tsx
@@ -35,7 +35,7 @@ export const SidebarMenu = memo(() => {
               permissions: ["CreateArticle", "DeleteArticle", "UpdateArticle", "ApproveArticle"],
             }}>
             <SidebarMenuItem href={routes.admin.articles.list} label="Gerenciar notícias" />
-            <SidebarMenuItem href={routes.admin.tags.list} label="Gerenciar tags de notícias" />
+            <SidebarMenuItem href={routes.admin.tags.list} label="Gerenciar tags" />
             <SidebarMenuItem
               href={routes.admin.articles.create}
               label="Nova notícia"

--- a/www/ui/articles/article-container.tsx
+++ b/www/ui/articles/article-container.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import { Chip } from "@/components/chip";
 import type { ArticleTag } from "@/types/article-tag";
 
 type Props = {
@@ -16,9 +17,9 @@ export const ArticleContainer = memo(({ title, tags, content }: Props) => {
         </header>
 
         {tags.length > 0 && (
-          <div id="article-tags-container" className="flex flex-wrap items-row gap-1 mb-3">
+          <div id="article-tags-container" className="flex flex-wrap items-row gap-1">
             {tags.map((tag) => (
-              <span key={`article-tag-${tag.id}`}>{tag.value}</span>
+              <Chip key={`article-tag-${tag.id}`}>{tag.value}</Chip>
             ))}
           </div>
         )}


### PR DESCRIPTION
This PR introduces CRUD pages to manage article tags from the admin dashboard. It also correctly displays article tags in the view page.