### PR TITLE
feat: improve imager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,6 +1058,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,6 +2556,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener 5.4.1",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3444,6 +3482,7 @@ dependencies = [
  "log",
  "migration",
  "mockall 0.13.1",
+ "moka",
  "password-auth",
  "rand 0.8.5",
  "regex",
@@ -4231,6 +4270,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ base64 = "0.22.1"
 sqlx = "0.8"
 url = "2.5.7"
 reqwest = "0.12.23"
+moka = { version = "0.12.12", features = ["future"] }
 
 [dev-dependencies]
 mockall = "0.13.0"

--- a/src/infra/http/controllers/tools/imager_controller.rs
+++ b/src/infra/http/controllers/tools/imager_controller.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
-use actix_web::web;
-use actix_web::web::Redirect;
+use actix_web::http::header;
+use actix_web::web::Data;
+use actix_web::{HttpResponse, web};
 
 use crate::error::SamambaiaError;
 use crate::infra::http::controllers::controller::ControllerTrait;
-use crate::infra::imager::factory::ImagerFactory;
-
+use crate::infra::imager::Imager;
 pub struct ImagerController;
 
 impl ControllerTrait for ImagerController {
@@ -18,7 +18,8 @@ impl ControllerTrait for ImagerController {
 impl ImagerController {
     async fn get_image(
         query: web::Query<HashMap<String, String>>,
-    ) -> Result<Redirect, SamambaiaError> {
+        imager: Data<Imager>,
+    ) -> Result<HttpResponse, SamambaiaError> {
         let mut params = query.into_inner();
         let nickname = match params.remove("user") {
             None => {
@@ -28,11 +29,12 @@ impl ImagerController {
             Some(nickname) => nickname,
         };
 
-        let imager_url = ImagerFactory::get_imager()
-            .mount_imager_url(&nickname, params)
-            .await?;
+        let imager_url = imager.mount_imager_url(&nickname, params).await?;
 
-        Ok(Redirect::to(imager_url).see_other())
+        Ok(HttpResponse::SeeOther()
+            .insert_header((header::LOCATION, imager_url))
+            .insert_header((header::REFERRER_POLICY, "no-referrer"))
+            .finish())
 
         // let image = reqwest::get(&imager_url).await.map_err(|err| {
         //     generate_service_internal_error(

--- a/src/infra/http/routes/tools.rs
+++ b/src/infra/http/routes/tools.rs
@@ -1,13 +1,20 @@
-use actix_web::web;
+use actix_web::web::{self, Data};
 
 use crate::infra::http::controllers::controller::ControllerTrait;
 use crate::infra::http::controllers::tools::imager_controller::ImagerController;
 use crate::infra::http::routes::route::RouteTrait;
+use crate::infra::imager::factory::ImagerFactory;
 
 pub struct ToolsRouter;
 
 impl RouteTrait for ToolsRouter {
     fn register(cfg: &mut actix_web::web::ServiceConfig) {
-        cfg.service(web::scope("tools").configure(ImagerController::register));
+        let imager = match ImagerFactory::get_imager() {
+            Err(err) => panic!("Could not instantiate an imager: {err}"),
+            Ok(imager) => Data::new(imager),
+        };
+
+        cfg.service(web::scope("tools").configure(ImagerController::register))
+            .app_data(imager);
     }
 }

--- a/src/infra/imager/factory.rs
+++ b/src/infra/imager/factory.rs
@@ -1,4 +1,5 @@
 use crate::configs::hotels::{AvailableHotel, HOTELS_CONFIG};
+use crate::error::SamambaiaError;
 use crate::infra::imager::Imager;
 use crate::infra::imager::providers::{
     HabbletImagerProvider,
@@ -9,19 +10,19 @@ use crate::infra::imager::providers::{
 pub struct ImagerFactory;
 
 impl ImagerFactory {
-    pub fn get_imager() -> Imager {
+    pub fn get_imager() -> Result<Imager, SamambaiaError> {
         let hotels_config = HOTELS_CONFIG.get_active_hotel_info();
 
-        let provider: Box<dyn ImagerProvider> = match HOTELS_CONFIG.active_hotel {
-            AvailableHotel::Habblet => Box::new(HabbletImagerProvider::new(
-                hotels_config.api_base_url,
-                hotels_config.imager_url,
-            )),
-            AvailableHotel::Habblive => {
-                Box::new(HabbliveImagerProvider::new(hotels_config.imager_url))
+        let provider = match HOTELS_CONFIG.active_hotel {
+            AvailableHotel::Habblet => {
+                HabbletImagerProvider::new(hotels_config.api_base_url, hotels_config.imager_url)
+                    .map(|provider| Box::new(provider) as Box<dyn ImagerProvider>)
             }
-        };
+            AvailableHotel::Habblive => Ok(Box::new(HabbliveImagerProvider::new(
+                hotels_config.imager_url,
+            )) as Box<dyn ImagerProvider>),
+        }?;
 
-        Imager::new(provider)
+        Ok(Imager::new(provider))
     }
 }

--- a/src/infra/imager/providers.rs
+++ b/src/infra/imager/providers.rs
@@ -1,7 +1,10 @@
 use core::panic;
+use std::borrow::Cow;
+use std::ops::Deref;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use moka::future::{Cache, CacheBuilder};
 use reqwest::Client;
 use serde::Deserialize;
 use url::Url;
@@ -23,6 +26,7 @@ pub struct HabbletImagerProvider<'this> {
     api_url: &'this str,
     imager_url: &'this str,
     http_client: Client,
+    cache: Cache<String, Cow<'static, str>>,
 }
 
 pub struct HabbliveImagerProvider<'this> {
@@ -49,10 +53,17 @@ impl<'this> HabbletImagerProvider<'this> {
                 )
             })?;
 
+        let cache = CacheBuilder::new(10_000)
+            .name("habblet user's figures")
+            .time_to_live(Duration::from_mins(15))
+            .time_to_idle(Duration::from_mins(5))
+            .build();
+
         Ok(Self {
             api_url,
             imager_url,
             http_client,
+            cache,
         })
     }
 }
@@ -66,30 +77,46 @@ impl<'this> HabbliveImagerProvider<'this> {
 #[async_trait]
 impl<'this> ImagerProvider for HabbletImagerProvider<'this> {
     async fn get_image_base_url(&self, nickname: &str) -> Result<Url, SamambaiaError> {
-        let response = self
-            .http_client
-            .get(format!("{}/player/{nickname}", self.api_url))
-            .send()
-            .await
-            .map_err(|err| {
-                generate_service_internal_error(
-                    "Failed to fetch user data on Habblet API",
-                    Box::new(err),
-                )
-            })?;
+        let user_figure = match self.cache.get(nickname).await {
+            Some(cached_figure) => {
+                log::debug!("pegou do cache");
+                cached_figure
+            }
+            None => {
+                let response = self
+                    .http_client
+                    .get(format!("{}/player/{nickname}", self.api_url))
+                    .send()
+                    .await
+                    .map_err(|err| {
+                        generate_service_internal_error(
+                            "Failed to fetch user data on Habblet API",
+                            Box::new(err),
+                        )
+                    })?;
 
-        let response = response.json::<UserMinimalData>().await.map_err(|err| {
-            generate_service_internal_error(
-                "Failed to serialize user data fetched from Habblet API",
-                Box::new(err),
-            )
-        })?;
+                let response = response.json::<UserMinimalData>().await.map_err(|err| {
+                    generate_service_internal_error(
+                        "Failed to serialize user data fetched from Habblet API",
+                        Box::new(err),
+                    )
+                })?;
+
+                let figure = Cow::<'static, str>::Owned(response.figure);
+
+                self.cache
+                    .insert(nickname.to_string(), figure.clone())
+                    .await;
+
+                figure
+            }
+        };
 
         let mut url = Url::parse(self.imager_url).unwrap_or_else(|err| {
             panic!("The given Habblet Imager URL set in Hotels Config is invalid, change it in configs crate: {err}");
         });
 
-        url.set_query(Some(&format!("figure={}", response.figure)));
+        url.set_query(Some(&format!("figure={}", user_figure.deref())));
         Ok(url)
     }
 }

--- a/src/infra/imager/providers.rs
+++ b/src/infra/imager/providers.rs
@@ -1,6 +1,8 @@
 use core::panic;
+use std::time::Duration;
 
 use async_trait::async_trait;
+use reqwest::Client;
 use serde::Deserialize;
 use url::Url;
 
@@ -20,6 +22,7 @@ pub trait ImagerProvider {
 pub struct HabbletImagerProvider<'this> {
     api_url: &'this str,
     imager_url: &'this str,
+    http_client: Client,
 }
 
 pub struct HabbliveImagerProvider<'this> {
@@ -27,11 +30,30 @@ pub struct HabbliveImagerProvider<'this> {
 }
 
 impl<'this> HabbletImagerProvider<'this> {
-    pub fn new(api_url: &'this str, imager_url: &'this str) -> Self {
-        Self {
+    pub fn new(api_url: &'this str, imager_url: &'this str) -> Result<Self, SamambaiaError> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        let fake_user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+        headers.insert(
+            "User-Agent",
+            reqwest::header::HeaderValue::from_static(fake_user_agent),
+        );
+
+        let http_client = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(Duration::from_secs(5))
+            .build()
+            .map_err(|err| {
+                generate_service_internal_error(
+                    "Error occurred when instantiating `HabbletImagerProvider`",
+                    Box::new(err),
+                )
+            })?;
+
+        Ok(Self {
             api_url,
             imager_url,
-        }
+            http_client,
+        })
     }
 }
 
@@ -44,7 +66,10 @@ impl<'this> HabbliveImagerProvider<'this> {
 #[async_trait]
 impl<'this> ImagerProvider for HabbletImagerProvider<'this> {
     async fn get_image_base_url(&self, nickname: &str) -> Result<Url, SamambaiaError> {
-        let response = reqwest::get(&format!("{}/player/{nickname}", self.api_url))
+        let response = self
+            .http_client
+            .get(format!("{}/player/{nickname}", self.api_url))
+            .send()
             .await
             .map_err(|err| {
                 generate_service_internal_error(


### PR DESCRIPTION
This PR refactors Habblet imager's provider to use singletone http clients for performing http requests to Habblet's users endpoints.

It also introduces a cache of user's figures, what reduced imager requests duration from 300ms (in average) to 1ms (in a low latency scenario).